### PR TITLE
Finished problems 44 and 45. 

### DIFF
--- a/problemsets-mat223/linearalbegra.tex
+++ b/problemsets-mat223/linearalbegra.tex
@@ -3091,25 +3091,43 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 	\end{parts}
 
 	\begin{definition}[Range]
-		The \emph{range} (or \emph{image}) of a linear transformation $T:V\to W$ is the set of vectors that
-		$T$ can output.  That is,
+		The \emph{range} (or \emph{image}) of a linear transformation $T:V\to W$ 
+		is the set of vectors that $T$ can output. That is,
 		\[
-			\Range(T)=\{\vec y\in W:\vec y=T\vec x\text{ for some }\vec x\in V\}.
+			\Range(T)=\Set{\vec y\in W \given \vec y=T\vec x\text{ for some }\vec x\in V}.
 		\]
 	\end{definition}
 	\begin{definition}[Null Space]
-		The \emph{null space} (or \emph{kernel}) of a linear transformation $T:V\to W$ is the
-		set of vectors that get mapped to zero under $T$.  That is,
+		The \emph{null space} (or \emph{kernel}) of a linear transformation $T:V\to W$
+		is the set of vectors that get mapped to zero under $T$. That is,
 		\[
-			\Null(T)=\{\vec x\in V:T\vec x=\vec 0\}.
+			\Null(T)=\Set{\vec x\in V \given T\vec x=\vec 0}.
 		\]
 	\end{definition}
 
 	\question
-	Let $\mathcal P:\R^2\to\R^2$ be projection onto $\Span\{\vec u\}$ where $\vec u=\mat{2\\3}$ (like before).
+	Let $\mathcal P:\R^2\to\R^2$ be projection onto $\Span\Set{\vec u}$ where
+	$\vec u=\mat{2\\3}$ (like before).
 	\begin{parts}
 		\item What is the range of $\mathcal P$?
+			\begin{solution}
+				$\Range(\mathcal P)=\Span\Set{\vec u}$.
+
+				Clearly $\mathcal P(\vec x) \in \Span\Set{\vec u}$ for all $\vec x\in\R^2$,
+				so $\Range(\mathcal P)\subseteq\Span\Set{\vec u}$. 
+				
+				On the other hand, $\mathcal P(\vec x)=\vec x$ for any 
+				$\vec x\in\Span\Set{\vec u}$, so $\Range(\mathcal P)\supseteq\Span\Set{\vec u}$
+			\end{solution}
 		\item What is the null space of $\mathcal P$?
+			\begin{solution}
+				\begin{solution}
+					$\Null(\mathcal P)=\Span\Set*{\mat{3\\-2}}$.
+
+					A vector $\vec x$ projects to $\vec 0$ if and only if $\vec x$
+					is on the line perpendicular to $\Span\Set{\vec u}$. 
+				\end{solution}
+			\end{solution}
 	\end{parts}
 
 	\question

--- a/problemsets-mat223/linearalbegra.tex
+++ b/problemsets-mat223/linearalbegra.tex
@@ -3134,7 +3134,31 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 	Let $T:\R^n\to\R^m$ be an arbitrary linear transformation.
 	\begin{parts}
 		\item Show that the null space of $T$ is a subspace.
+			\begin{solution}
+				\begin{enumerate}[label=(\roman*)]
+					\item Let $\vec u,\vec v\in\Null(T)$. Then 
+						$T(\vec u+\vec v)=T(\vec u)+T(\vec v)=\vec 0+\vec 0=\vec 0$,
+						and so $\vec u+\vec v\in\Null(T)$. 
+					\item Let $\vec u\in\Null(T)$ and let $\alpha$ be any scalar.
+						Then $T(\alpha\vec u)=\alpha T(\vec u)=\alpha\vec 0=\vec 0$,
+						and so $\alpha\vec u\in\Null(T)$.
+				\end{enumerate}
+			\end{solution}
 		\item Show that the range of $T$ is a subspace.
+			\begin{solution}
+				\begin{enumerate}[label=(\roman*)]
+					\item Let $\vec y,\vec z\in\Range(T)$. 
+						Then there exist $\vec u,\vec v\in\R^n$ such that $T(\vec u)=\vec y$
+						and $T(\vec v)=\vec z$. Then
+						$\vec y+\vec z=T(\vec u)+T(\vec v)=T(\vec u+\vec v)$,
+						and so $\vec y+\vec z\in\Range(T)$. 
+					\item Let $\vec y\in\Range(T)$ and let $\alpha$ be any scalar.
+						Then there exists $\vec u\in\R^n$ such that $T(\vec u)=\vec y$,
+						and $\alpha\vec y=\alpha T(\vec u)=T(\alpha\vec u)$,
+						and so $\alpha\vec y\in\Range(T)$.
+				\end{enumerate}
+
+			\end{solution}
 	\end{parts}
 
 	\begin{definition}[Induced Transformation]

--- a/problemsets-mat223/linearalbegra.tex
+++ b/problemsets-mat223/linearalbegra.tex
@@ -3113,11 +3113,13 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 			\begin{solution}
 				$\Range(\mathcal P)=\Span\Set{\vec u}$.
 
-				Clearly $\mathcal P(\vec x) \in \Span\Set{\vec u}$ for all $\vec x\in\R^2$,
-				so $\Range(\mathcal P)\subseteq\Span\Set{\vec u}$. 
+				$\mathcal P(\vec x)$ is by definition the vector in $\Span\Set{\vec u}$ 
+				that is closest to $\vec x$, so in particular 
+				$\mathcal P(\vec x) \in \Span\Set{\vec u}$ for all $\vec x\in\R^2$.
+				Therefore $\Range(\mathcal P)\subseteq\Span\Set{\vec u}$. 
 				
-				On the other hand, $\mathcal P(\vec x)=\vec x$ for any 
-				$\vec x\in\Span\Set{\vec u}$, so $\Range(\mathcal P)\supseteq\Span\Set{\vec u}$
+				On the other hand, $\mathcal P(\alpha \vec u)=\alpha\mathcal P(\vec u)=\alpha\vec u$ 
+				for any scalar $\alpha$, and so $\Range(\mathcal P)\supseteq\Span\Set{\vec u}$
 			\end{solution}
 		\item What is the null space of $\mathcal P$?
 			\begin{solution}
@@ -3125,7 +3127,8 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 					$\Null(\mathcal P)=\Span\Set*{\mat{3\\-2}}$.
 
 					A vector $\vec x$ projects to $\vec 0$ if and only if $\vec x$
-					is on the line perpendicular to $\Span\Set{\vec u}$. 
+					is on the line perpendicular to $\Span\Set{\vec u}$ passing
+					through the origin. 
 				\end{solution}
 			\end{solution}
 	\end{parts}
@@ -3136,11 +3139,13 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 		\item Show that the null space of $T$ is a subspace.
 			\begin{solution}
 				\begin{enumerate}[label=(\roman*)]
-					\item Let $\vec u,\vec v\in\Null(T)$. Then 
+					\item Let $\vec u,\vec v\in\Null(T)$. 
+						Applying the linearity of $T$ we see
 						$T(\vec u+\vec v)=T(\vec u)+T(\vec v)=\vec 0+\vec 0=\vec 0$,
 						and so $\vec u+\vec v\in\Null(T)$. 
 					\item Let $\vec u\in\Null(T)$ and let $\alpha$ be any scalar.
-						Then $T(\alpha\vec u)=\alpha T(\vec u)=\alpha\vec 0=\vec 0$,
+						Again using the linearity of $T$ we see
+						$T(\alpha\vec u)=\alpha T(\vec u)=\alpha\vec 0=\vec 0$,
 						and so $\alpha\vec u\in\Null(T)$.
 				\end{enumerate}
 			\end{solution}
@@ -3151,11 +3156,11 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 						Then there exist $\vec u,\vec v\in\R^n$ such that $T(\vec u)=\vec y$
 						and $T(\vec v)=\vec z$. Then
 						$\vec y+\vec z=T(\vec u)+T(\vec v)=T(\vec u+\vec v)$,
-						and so $\vec y+\vec z\in\Range(T)$. 
+						since $T$ is linear, and so $\vec y+\vec z\in\Range(T)$. 
 					\item Let $\vec y\in\Range(T)$ and let $\alpha$ be any scalar.
 						Then there exists $\vec u\in\R^n$ such that $T(\vec u)=\vec y$,
-						and $\alpha\vec y=\alpha T(\vec u)=T(\alpha\vec u)$,
-						and so $\alpha\vec y\in\Range(T)$.
+						and $\alpha\vec y=\alpha T(\vec u)=T(\alpha\vec u)$, 
+						since $T$ is linear, and so $\alpha\vec y\in\Range(T)$.
 				\end{enumerate}
 
 			\end{solution}

--- a/problemsets-mat223/linearalbegra.tex
+++ b/problemsets-mat223/linearalbegra.tex
@@ -3119,7 +3119,7 @@ Two students---Pat and Jamie---explained their approach to the Italicizing N tas
 				Therefore $\Range(\mathcal P)\subseteq\Span\Set{\vec u}$. 
 				
 				On the other hand, $\mathcal P(\alpha \vec u)=\alpha\mathcal P(\vec u)=\alpha\vec u$ 
-				for any scalar $\alpha$, and so $\Range(\mathcal P)\supseteq\Span\Set{\vec u}$
+				for any scalar $\alpha$, and so $\Range(\mathcal P)=\Span\Set{\vec u}$.
 			\end{solution}
 		\item What is the null space of $\mathcal P$?
 			\begin{solution}


### PR DESCRIPTION
I noticed while doing this problem that the definitions/statements of problems are a little inconsistent about how to notate transformations and matrices acting on things. In some places it uses brackets (like "T(x)", in Problem 43, for example) and in other places it doesn't (like "Tx", in the definitions of range and nullspace, for example).

Is this intentional? Or do you want me to make it consistently one way or the other?