### PR TITLE
A more precise definition of X?

### DIFF
--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -278,7 +278,7 @@
 
 
 \begin{SaveDefinition}[key=Projection, title={Projection}]
-	Let $X$ be a set. The
+	Let $X$ be a set of vectors. The
 	\emph{projection} of the vector $\vec v$ onto $X$, written $\Proj_{X}\vec
 	v$, is the closest point in $X$ to $\vec v$.
 \end{SaveDefinition}


### PR DESCRIPTION
The current definition allows for X to be an arbitrary set, without restrictions on its contents. It could be a set of people, in which case the definition wouldn't make sense.

So I propose to define X as a set of vectors, or a set of points.

Might it also be a good idea to be even more precise, and define X as a set of vectors that is a subset of R^n, and then define vector v as an element of R^n as well? Because I'm not sure if a projection of a vector of a certain dimension onto a set of a different dimension would make sense.