### PR TITLE
possible typo in three facts about bases

### DIFF
--- a/problemsets-mat223/modules/module6.tex
+++ b/problemsets-mat223/modules/module6.tex
@@ -297,7 +297,7 @@ There are several facts everyone should know about bases:
 	\item Bases are not unique. Every subspace (except the trivial subspace)
 		has multiple bases.
 	\item Given a basis for a subspace, every vector in the subspace can be written
-		as a \emph{unique} linear combination of vectors in that subspace.
+		as a \emph{unique} linear combination of vectors in that basis.
 	\item Any two bases for the same subspace have the same number of elements.
 \end{enumerate}
 


### PR DESCRIPTION
I think this was meant to say 'basis' not 'subspace', since every vector in a subspace can be written in multiple ways in terms of vectors in the subspace, but only one way (uniquely) in terms of vectors in the basis.