### PR TITLE
fixed mathematical typo ('n' -> 'm')

### DIFF
--- a/problemsets-mat223/modules/module11.tex
+++ b/problemsets-mat223/modules/module11.tex
@@ -74,7 +74,7 @@ we can consider this question anew.
 Just like the range of a linear transformation, the null space of a linear transformation is always a subspace.
 
 \begin{theorem}
-	Let $T:\R^n\to\R^m$ be a linear transformation. Then $\Null(T)\subseteq \R^n$ is a subspace.
+	Let $T:\R^n\to\R^m$ be a linear transformation. Then $\Null(T)\subseteq \R^m$ is a subspace.
 \end{theorem}
 \begin{proof}
 	Since $T$ is linear, $T(\vec 0)=\vec 0$ and so $\vec 0\in\Null(T)$ which shows that $\Null(T)$ is non-empty.


### PR DESCRIPTION
The nullspace of T is a subset of the range of T, which is a subset of the co-domain of T, `R^m`.