### PR TITLE
Fixed transpose definition

### DIFF
--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -469,17 +469,17 @@
 			a_{11}&a_{12}&a_{13}&\cdots & a_{1m}\\
 		a_{21}&a_{22}&a_{23}&\cdots&a_{2m}\\
 		\vdots &\vdots&\vdots &\ddots&\vdots\\
-		a_{n1}&a_{n2}&a_{3n}&\cdots&a_{nm}}.
+		a_{n1}&a_{n2}&a_{n3}&\cdots&a_{nm}}.
 	\]
 	The \emph{transpose} of $M$, notated $M^T$, is the $m\times n$ matrix produced by swapping the rows
 	and columns of $M$. That is
 	\[
 		M^T=\matc{
-		a_{11}&a_{21}&\cdots&a_{m1}\\
-		a_{12}&a_{22}&\cdots&a_{m2}\\
-		a_{13}&a_{23}&\cdots&a_{m3}\\
+		a_{11}&a_{21}&\cdots&a_{n1}\\
+		a_{12}&a_{22}&\cdots&a_{n2}\\
+		a_{13}&a_{23}&\cdots&a_{n3}\\
 		\vdots&\vdots&\ddots&\vdots\\
-		a_{1n}&a_{2n}&\cdots&a_{mn}}.
+		a_{1m}&a_{2m}&\cdots&a_{nm}}.
 	\]
 \end{SaveDefinition}
 


### PR DESCRIPTION
Swapped variables around so the definition makes sense

See https://i.imgur.com/CqfMz7F.png for a visual rationale

Edit: Since the variables `n` and `m` are used exclusively for rows and columns respectively in the rest of the course, perhaps they should should be exchanged with something else, like `c` and `r`, in this definition, to avoid confusing the students.