### PR TITLE
Null space definition suggestion #1

### DIFF
--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -438,7 +438,7 @@
 	The
 	\emph{null space} (or
 	\emph{kernel}) of a linear transformation $T:V\to W$ is the set of vectors
-	that get mapped to zero under $T$. That is,
+	that get mapped to the zero vector under $T$. That is,
 	\[
 		\Null(T)=\Set{\vec x\in V \given T\vec x=\vec 0}.
 	\]


### PR DESCRIPTION
Changed `zero` to `the zero vector`, since zero is only a vector in R^1.