### PR TITLE
Add index for Module 1 and 2

### DIFF
--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -5,8 +5,8 @@
 		key=SubsetSuperset,
 		title={Subset \& Superset}
 	]
-	The set $B$ is a \emph{subset} of the set $A$, written $B\subseteq A$, if for all
-	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}
+	The set $B$ is a \emph{subset}\index[definitions]{subset} of the set $A$, written $B\subseteq A$\index{\(\subseteq\)}, if for all
+	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}\index{superset}\index{set!superset}\index[definitions]{superset}\index[definitions]{set!superset}
 	of $B$.\footnote{
 		Some mathematicians use the symbol $\subset$ instead of $\subseteq$.}
 \end{SaveDefinition}
@@ -14,13 +14,13 @@
 		key=SetEquality,
 		title={Set Equality}
 	]
-	The sets $A$ and $B$ are \emph{equal}, written $A=B$, if $A\subseteq B$ and $B\subseteq A$.
+	The sets $A$ and $B$ are \emph{equal}\index{set!equality}\index[definitions]{set!equality}\index{set equality}\index[definitions]{set equality}, written $A=B$, if $A\subseteq B$ and $B\subseteq A$.
 \end{SaveDefinition}
 \begin{SaveDefinition}[
 		key=SetSubtraction,
 		title={Set Subtraction}
 	]
-	For sets $A$ and $B$, the \emph{set-wise difference}\index{set subtraction} between $A$ and $B$,
+	For sets $A$ and $B$, the \emph{set-wise difference}\index[definitions]{set!subtraction}\index[definitions]{set subtraction}\index{set!subtraction}\index{set subtraction} between $A$ and $B$,
 	written $A\backslash B$, is the set
 	\[
 		A\backslash B = \Set{x\given x\in A\text{ and }x\notin B}.
@@ -30,7 +30,8 @@
 		key=UnionsIntersections,
 		title={Unions \& Intersections}
 	]
-	Let $X$ and $Y$ be sets. The \emph{union} of $X$ and $Y$ and the \emph{intersection} of $X$
+	Let $X$ and $Y$ be sets. The \emph{union}\index[definitions]{set!union}\index{set!union}\index[definitions]{union}\index{union}\index{\(\cup\)} of $X$ and $Y$ and the 
+	\emph{intersection}\index[definitions]{set!intersection}\index{set!intersection}\index[definitions]{intersection}\index{intersection}\index{\(\cap\)} of $X$
 	and $Y$ are defined as follows.
 
 	\smallskip
@@ -44,7 +45,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Set, title={Set}]
-	A \emph{set} is a (possibly infinite) collection of items and is notated
+	A \emph{set}\index{set}\index[definition]{set} is a (possibly infinite) collection of items and is notated
 	with curly braces (for example, $\{1,2,3\}$ is the set containing the
 	numbers 1, 2, and 3). We call the items in a set
 	\emph{elements}.
@@ -71,19 +72,19 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ZeroVector, title={Zero Vector}]
-		The \emph{zero vector}\index{zero vector}, notated as $\vec 0$\index{$\vec 0$},
+		The \emph{zero vector}\index{zero vector}\index[definitions]{zero vector}\index{vector!zero vector}\index[definitions]{vector!zero vector}, notated as $\vec 0$\index{$\vec 0$},
 		is the vector with no magnitude.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=LinearCombination, title={Linear Combination}]
-	A \emph{linear combination}\index[definitions]{Linear combination} of the vectors
+	A \emph{linear combination}\index{linear combination}\index[definitions]{Linear combination} of the vectors
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ is a vector
 	\[
 		\vec w = \alpha_{1}\vec v_{1}+\alpha_{2}\vec v_{2}+\cdots+\alpha_{n}\vec
 		v_{n}.
 	\]
 	 The scalars $\alpha_{1},\alpha_{2},\ldots,\alpha_{n}$ are called the
-	\emph{coefficients} of the linear combination.
+	\emph{coefficients}\index{linear combination!coefficient}\index[definitions]{Linear combination!coefficient} of the linear combination.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -94,12 +95,12 @@
 	$\vec w=\alpha_{1}\vec v_{1}+\alpha_{2}\vec v_{2}+\cdots+\alpha_{n}\vec
 	v_{n}.$
 	The vector $\vec w$ is called a 
-	\emph{non-negative}\index[definitions]{Linear combination!non-negative} linear combination of
+	\emph{non-negative}\index{non-negative linear combination}\index[definitions]{non-negative linear combination}\index{Linear combination!non-negative}\index[definitions]{Linear combination!non-negative} linear combination of
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ if
 	\[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0.\]
 
 	The vector $\vec w$ is called a 
-	\emph{convex}\index[definitions]{Linear combination!convex} linear combination of
+	\emph{convex}\index{convex linear combiantion}\index[definitions]{convex linear combiantion}\index{Linear combination!convex}\index[definitions]{Linear combination!convex} linear combination of
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$
 	if \[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0\qquad\text{and}\qquad
 	\alpha_{1}+\alpha_{2}+\cdots+\alpha_{n}=1.\]
@@ -113,13 +114,13 @@
 		\vec x=t\vec d+\vec p
 	\]
 	 is $\ell$ expressed in
-	\emph{vector form}. The vector $\vec d$ is called a
-	\emph{direction vector} for $\ell$.
+	\emph{vector form}\index{line!vector form}\index[definitions]{line!vector form}. The vector $\vec d$ is called a
+	\emph{direction vector}\index{line!direction vector}\index[definitions]{line!direction vector} for $\ell$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=VectorFormofaPlane, title={Vector Form of a Plane}]
 	A plane $\mathcal P$ is written in
-	\emph{vector form} if it is expressed as
+	\emph{vector form}\index{plane!vector form}\index[definitions]{plane!vector form} if it is expressed as
 	\[
 		\vec x=t\vec d_{1} +s\vec d_{2}+\vec p
 	\]
@@ -127,15 +128,15 @@
 	is,
 	$\mathcal P = \{\vec x: \vec x= t\vec d_{1}+s\vec d_{2} +\vec p\text{ for
 	some }t,s\in\R \}$. The vectors $\vec d_{1}$ and $\vec d_{2}$ are called
-	\emph{direction vectors} for $\mathcal P$.
+	\emph{direction vectors}\index{plane!direction vector}\index[definitions]{plane!direction vector} for $\mathcal P$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Span, title={Span}]
 	The
-	\emph{span} of a set of vectors $V$ is the set of all linear
+	\emph{span}\index{span}\index[definitions]{span} of a set of vectors $V$ is the set of all linear
 	combinations of vectors in $V$. That is,
 	\[
-		\Span V = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
+		\Span V\index{\(\Span V\)} = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
 		v_2 + \cdots +\alpha_n\vec v_n\text{ for some }\vec v_1,\vec v_2,\ldots,\vec
 		v_n\in V \text{ and scalars }\alpha_1,\alpha_2,\ldots,\alpha_n}.
 	\]
@@ -145,7 +146,7 @@
 
 \begin{SaveDefinition}[key=SetAddition, title={Set Addition}]
 	If $A$ and $B$ are sets of vectors, then the
-	\emph{set sum} of $A$ and $B$, denoted $A+B$, is
+	\emph{set sum}\index{set sum}\index[definitions]{set sum} of $A$ and $B$, denoted $A+B$, is
 	\[
 		A+B=\Set{\vec x \given \vec x=\vec a+\vec b\text{ for some }\vec
 		a\in A\text{ and } \vec b\in B}.
@@ -158,13 +159,13 @@
 	title={Linearly Dependent \& Independent (Geometric)}]
 
 	We say the vectors $\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ are
-	\emph{linearly dependent} if for at least one $i$,
+	\emph{linearly dependent}\index{linearly dependent}\index[definitions]{linearly dependent}\index[definitions]{linearly dependent!(geometric)} if for at least one $i$,
 	\[
 		\vec v_{i}\in\Span\Set{\vec v_1,\vec v_2,\ldots,\vec v_{i-1}, \vec
 		v_{i+1},\ldots,\vec v_n}.
 	\]
 	 Otherwise, they are called
-	\emph{linearly independent}.
+	\emph{linearly independent}\index{linearly independent}\index[definitions]{linearly independent}\index[definitions]{linearly independent!(geometric)}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -172,10 +173,12 @@
 	title={Trivial Linear Combination}]
 
 	The linear combination $\alpha_1\vec v_1+\cdots+\alpha_n\vec v_n$ is called
-	\emph{trivial}\index{trivial linear combination}
+	\emph{trivial}\index{trivial linear combination}\index{linear combination!trivial}
 	if $\alpha_1=\cdots=\alpha_n=0$. If at least one $\alpha_i\neq 0$,
 	the linear combination is called \emph{non-trivial}.
 \end{SaveDefinition}
+
+% 2020/6/9 Above; editing finished; review
 
 \begin{SaveDefinition}[
 	key=LinearlyDependentIndependentAlgebraic,

--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -5,8 +5,8 @@
 		key=SubsetSuperset,
 		title={Subset \& Superset}
 	]
-	The set $B$ is a \emph{subset}\index[definitions]{subset} of the set $A$, written $B\subseteq A$\index{\(\subseteq\)}, if for all
-	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}\index{superset}\index{set!superset}\index[definitions]{superset}\index[definitions]{set!superset}
+	The set $B$ is a \emph{subset}\index[definitions]{Subset} of the set $A$, written $B\subseteq A$\index[symbols]{$\subseteq$}, if for all
+	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}\index{Superset}\index[definitions]{Superset}
 	of $B$.\footnote{
 		Some mathematicians use the symbol $\subset$ instead of $\subseteq$.}
 \end{SaveDefinition}
@@ -14,13 +14,13 @@
 		key=SetEquality,
 		title={Set Equality}
 	]
-	The sets $A$ and $B$ are \emph{equal}\index{set!equality}\index[definitions]{set!equality}\index{set equality}\index[definitions]{set equality}, written $A=B$, if $A\subseteq B$ and $B\subseteq A$.
+	The sets $A$ and $B$ are \emph{equal}\index{Set!equality}\index[definitions]{Set!equality}, written $A=B$, if $A\subseteq B$ and $B\subseteq A$.
 \end{SaveDefinition}
 \begin{SaveDefinition}[
 		key=SetSubtraction,
 		title={Set Subtraction}
 	]
-	For sets $A$ and $B$, the \emph{set-wise difference}\index[definitions]{set!subtraction}\index[definitions]{set subtraction}\index{set!subtraction}\index{set subtraction} between $A$ and $B$,
+	For sets $A$ and $B$, the \emph{set-wise difference}\index[definitions]{Set!subtraction}\index{Set!subtraction} between $A$ and $B$,
 	written $A\backslash B$, is the set
 	\[
 		A\backslash B = \Set{x\given x\in A\text{ and }x\notin B}.
@@ -30,8 +30,8 @@
 		key=UnionsIntersections,
 		title={Unions \& Intersections}
 	]
-	Let $X$ and $Y$ be sets. The \emph{union}\index[definitions]{set!union}\index{set!union}\index[definitions]{union}\index{union}\index{\(\cup\)} of $X$ and $Y$ and the 
-	\emph{intersection}\index[definitions]{set!intersection}\index{set!intersection}\index[definitions]{intersection}\index{intersection}\index{\(\cap\)} of $X$
+	Let $X$ and $Y$ be sets. The \emph{union}\index[definitions]{Set!union}\index{Set!union}\index[symbols]{$\cup$} of $X$ and $Y$ and the 
+	\emph{intersection}\index[definitions]{Set!intersection}\index{Set!intersection}\index[symbols]{$\cap$} of $X$
 	and $Y$ are defined as follows.
 
 	\smallskip
@@ -45,7 +45,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Set, title={Set}]
-	A \emph{set}\index{set}\index[definition]{set} is a (possibly infinite) collection of items and is notated
+	A \emph{set}\index{Set}\index[definition]{Set} is a (possibly infinite) collection of items and is notated
 	with curly braces (for example, $\{1,2,3\}$ is the set containing the
 	numbers 1, 2, and 3). We call the items in a set
 	\emph{elements}.
@@ -72,19 +72,19 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ZeroVector, title={Zero Vector}]
-		The \emph{zero vector}\index{zero vector}\index[definitions]{zero vector}\index{vector!zero vector}\index[definitions]{vector!zero vector}, notated as $\vec 0$\index{$\vec 0$},
+		The \emph{zero vector}\index{Vector!zero}\index[definitions]{Vector!zero}, notated as $\vec 0$[\index[symbols]{$\vec 0$},
 		is the vector with no magnitude.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=LinearCombination, title={Linear Combination}]
-	A \emph{linear combination}\index{linear combination}\index[definitions]{Linear combination} of the vectors
+	A \emph{linear combination}\index{Linear combination}\index[definitions]{Linear combination} of the vectors
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ is a vector
 	\[
 		\vec w = \alpha_{1}\vec v_{1}+\alpha_{2}\vec v_{2}+\cdots+\alpha_{n}\vec
 		v_{n}.
 	\]
 	 The scalars $\alpha_{1},\alpha_{2},\ldots,\alpha_{n}$ are called the
-	\emph{coefficients}\index{linear combination!coefficient}\index[definitions]{Linear combination!coefficient} of the linear combination.
+	\emph{coefficients}\index{Linear combination!coefficient of}\index[definitions]{Linear combination!coefficient of} of the linear combination.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -95,12 +95,12 @@
 	$\vec w=\alpha_{1}\vec v_{1}+\alpha_{2}\vec v_{2}+\cdots+\alpha_{n}\vec
 	v_{n}.$
 	The vector $\vec w$ is called a 
-	\emph{non-negative}\index{non-negative linear combination}\index[definitions]{non-negative linear combination}\index{Linear combination!non-negative}\index[definitions]{Linear combination!non-negative} linear combination of
+	\emph{non-negative}\index{Linear combination!non-negative}\index[definitions]{Linear combination!non-negative} linear combination of
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ if
 	\[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0.\]
 
 	The vector $\vec w$ is called a 
-	\emph{convex}\index{convex linear combiantion}\index[definitions]{convex linear combiantion}\index{Linear combination!convex}\index[definitions]{Linear combination!convex} linear combination of
+	\emph{convex}\index{Linear combiantion!convex}\index[definitions]{Linear combiantion!convex} linear combination of
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$
 	if \[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0\qquad\text{and}\qquad
 	\alpha_{1}+\alpha_{2}+\cdots+\alpha_{n}=1.\]
@@ -114,13 +114,13 @@
 		\vec x=t\vec d+\vec p
 	\]
 	 is $\ell$ expressed in
-	\emph{vector form}\index{line!vector form}\index[definitions]{line!vector form}. The vector $\vec d$ is called a
-	\emph{direction vector}\index{line!direction vector}\index[definitions]{line!direction vector} for $\ell$.
+	\emph{vector form}\index{Line!vector form of}\index[definitions]{Line!vector form of}. The vector $\vec d$ is called a
+	\emph{direction vector}\index{Line!direction vector for}\index[definitions]{Line!direction vector for} for $\ell$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=VectorFormofaPlane, title={Vector Form of a Plane}]
 	A plane $\mathcal P$ is written in
-	\emph{vector form}\index{plane!vector form}\index[definitions]{plane!vector form} if it is expressed as
+	\emph{vector form}\index{Plane!vector form of}\index[definitions]{Plane!vector form of} if it is expressed as
 	\[
 		\vec x=t\vec d_{1} +s\vec d_{2}+\vec p
 	\]
@@ -128,15 +128,15 @@
 	is,
 	$\mathcal P = \{\vec x: \vec x= t\vec d_{1}+s\vec d_{2} +\vec p\text{ for
 	some }t,s\in\R \}$. The vectors $\vec d_{1}$ and $\vec d_{2}$ are called
-	\emph{direction vectors}\index{plane!direction vector}\index[definitions]{plane!direction vector} for $\mathcal P$.
+	\emph{direction vectors}\index{Plane!direction vector for}\index[definitions]{Plane!direction vector for} for $\mathcal P$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Span, title={Span}]
 	The
-	\emph{span}\index{span}\index[definitions]{span} of a set of vectors $V$ is the set of all linear
+	\emph{span}\index{Span}\index[definitions]{Span} of a set of vectors $V$ is the set of all linear
 	combinations of vectors in $V$. That is,
 	\[
-		\Span V\index{\(\Span V\)} = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
+		\Span V\index[symbols]{$\Span V$} = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
 		v_2 + \cdots +\alpha_n\vec v_n\text{ for some }\vec v_1,\vec v_2,\ldots,\vec
 		v_n\in V \text{ and scalars }\alpha_1,\alpha_2,\ldots,\alpha_n}.
 	\]
@@ -146,7 +146,7 @@
 
 \begin{SaveDefinition}[key=SetAddition, title={Set Addition}]
 	If $A$ and $B$ are sets of vectors, then the
-	\emph{set sum}\index{set sum}\index[definitions]{set sum} of $A$ and $B$, denoted $A+B$, is
+	\emph{set sum}\index{Set sum}\index[definitions]{Set sum} of $A$ and $B$, denoted $A+B$, is
 	\[
 		A+B=\Set{\vec x \given \vec x=\vec a+\vec b\text{ for some }\vec
 		a\in A\text{ and } \vec b\in B}.
@@ -159,13 +159,13 @@
 	title={Linearly Dependent \& Independent (Geometric)}]
 
 	We say the vectors $\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ are
-	\emph{linearly dependent}\index{linearly dependent}\index[definitions]{linearly dependent}\index[definitions]{linearly dependent!(geometric)} if for at least one $i$,
+	\emph{linearly dependent}\index{Linearly dependent}\index[definitions]{Linearly dependent}\index[definitions]{Linearly dependent!(geometric)} if for at least one $i$,
 	\[
 		\vec v_{i}\in\Span\Set{\vec v_1,\vec v_2,\ldots,\vec v_{i-1}, \vec
 		v_{i+1},\ldots,\vec v_n}.
 	\]
 	 Otherwise, they are called
-	\emph{linearly independent}\index{linearly independent}\index[definitions]{linearly independent}\index[definitions]{linearly independent!(geometric)}.
+	\emph{linearly independent}\index{Linearly independent}\index[definitions]{Linearly independent}\index[definitions]{Linearly independent!(geometric)}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -173,7 +173,7 @@
 	title={Trivial Linear Combination}]
 
 	The linear combination $\alpha_1\vec v_1+\cdots+\alpha_n\vec v_n$ is called
-	\emph{trivial}\index{trivial linear combination}\index{linear combination!trivial}
+	\emph{trivial}\index{Linear combination!trivial}
 	if $\alpha_1=\cdots=\alpha_n=0$. If at least one $\alpha_i\neq 0$,
 	the linear combination is called \emph{non-trivial}.
 \end{SaveDefinition}

--- a/problemsets-mat223/definitions.tex
+++ b/problemsets-mat223/definitions.tex
@@ -6,7 +6,7 @@
 		title={Subset \& Superset}
 	]
 	The set $B$ is a \emph{subset}\index[definitions]{Subset} of the set $A$, written $B\subseteq A$\index[symbols]{$\subseteq$}, if for all
-	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}\index{Superset}\index[definitions]{Superset}
+	$b\in B$ we also have $b\in A$.  In this case, $A$ is called a \emph{superset}\index[definitions]{Superset}
 	of $B$.\footnote{
 		Some mathematicians use the symbol $\subset$ instead of $\subseteq$.}
 \end{SaveDefinition}
@@ -45,7 +45,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Set, title={Set}]
-	A \emph{set}\index{Set}\index[definition]{Set} is a (possibly infinite) collection of items and is notated
+	A \emph{set}\index[definitions]{Set} is a (possibly infinite) collection of items and is notated
 	with curly braces (for example, $\{1,2,3\}$ is the set containing the
 	numbers 1, 2, and 3). We call the items in a set
 	\emph{elements}.
@@ -72,7 +72,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ZeroVector, title={Zero Vector}]
-		The \emph{zero vector}\index{Vector!zero}\index[definitions]{Vector!zero}, notated as $\vec 0$[\index[symbols]{$\vec 0$},
+		The \emph{zero vector}\index{Zero vector ($\vec 0$)}\index[definitions]{Zero vector ($\vec 0$)}, notated as $\vec 0$[\index[symbols]{$\vec 0$},
 		is the vector with no magnitude.
 \end{SaveDefinition}
 
@@ -100,7 +100,7 @@
 	\[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0.\]
 
 	The vector $\vec w$ is called a 
-	\emph{convex}\index{Linear combiantion!convex}\index[definitions]{Linear combiantion!convex} linear combination of
+	\emph{convex}\index{Linear combination!convex}\index[definitions]{Linear combination!convex} linear combination of
 	$\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$
 	if \[\alpha_{1},\alpha_{2},\ldots,\alpha_{n}\geq 0\qquad\text{and}\qquad
 	\alpha_{1}+\alpha_{2}+\cdots+\alpha_{n}=1.\]
@@ -136,10 +136,11 @@
 	\emph{span}\index{Span}\index[definitions]{Span} of a set of vectors $V$ is the set of all linear
 	combinations of vectors in $V$. That is,
 	\[
-		\Span V\index[symbols]{$\Span V$} = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
+		\Span V = \Set{\vec v \given \vec v=\alpha_1\vec v_1+\alpha_2\vec
 		v_2 + \cdots +\alpha_n\vec v_n\text{ for some }\vec v_1,\vec v_2,\ldots,\vec
 		v_n\in V \text{ and scalars }\alpha_1,\alpha_2,\ldots,\alpha_n}.
 	\]
+	\index[symbols]{$\Span V$}
 
 	Additionally, we define $\Span\Set{} = \Set{\vec 0}$.
 \end{SaveDefinition}
@@ -159,13 +160,13 @@
 	title={Linearly Dependent \& Independent (Geometric)}]
 
 	We say the vectors $\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ are
-	\emph{linearly dependent}\index{Linearly dependent}\index[definitions]{Linearly dependent}\index[definitions]{Linearly dependent!(geometric)} if for at least one $i$,
+	\emph{linearly dependent}\index{Linearly dependent} if for at least one $i$,
 	\[
 		\vec v_{i}\in\Span\Set{\vec v_1,\vec v_2,\ldots,\vec v_{i-1}, \vec
 		v_{i+1},\ldots,\vec v_n}.
 	\]
 	 Otherwise, they are called
-	\emph{linearly independent}\index{Linearly independent}\index[definitions]{Linearly independent}\index[definitions]{Linearly independent!(geometric)}.
+	\emph{linearly independent}\index{Linearly independent}\index[definitions]{Linear dependence/independence!geometric definition}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -187,7 +188,7 @@
 	The vectors $\vec v_{1},\vec v_{2},\ldots,\vec v_{n}$ are
 	\emph{linearly dependent} if there is a non-trivial linear combination
 	of $\vec v_{1},\ldots,\vec v_{n}$ that equals the zero vector. Otherwise they
-	are linearly independent.
+	are linearly independent\index[definitions]{Linear dependence/independence!algebraic definition}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[

--- a/problemsets-mat223/linearalgebra.tex
+++ b/problemsets-mat223/linearalgebra.tex
@@ -1,11 +1,11 @@
 
 % WARNING!  Do not type any of the following 10 characters except as directed:
-%                &   $   #   %   _   {   }   ^   ~   \   
+%                &   $   #   %   _   {   }   ^   ~   \
 %
 %%
 %%  default option for pdfx.sty  if not specified on the command-line.
 \providecommand{\pdfxopt}{a-1b}
-%% 
+%%
 %%  Use  {filecontents}  for the  .xmpdata file before input encoding is specified.
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -17,7 +17,7 @@
 	\Title{Linear Algebra (\jobname)}%  *not* set by LaTeX's  \title
 	\Author{Jason Siefken\sep et al.}% *not* set by LaTeX's \author
 	\Subject{Linear Algebra textbook/workbook}
-	\Keywords{linear algebra\sep vectors\sep mathematics\sep textbook} 
+	\Keywords{linear algebra\sep vectors\sep mathematics\sep textbook}
 	\Org{University of Toronto}
 	\CreatorTool{LaTeX + pdfx.sty with options \pdfxopt}
 	\Copyright{Jason Siefken}
@@ -26,7 +26,7 @@
 	\CoverDate{2019-08-014}%  must be in format  YYYY-MM-DD  or  YYYY-MM
 	\Doi{0.0.0.0}%
 	%
-	% setting the color profile, these reproduce the defaults; use your own, if required 
+	% setting the color profile, these reproduce the defaults; use your own, if required
 	%
 	% RGB is used with PDF/A (4 parameters):
 	\setRGBcolorprofile{sRGB_IEC61966-2-1_black_scaled.icc}{sRGB_IEC61966-2-1_black_scaled}{sRGB IEC61966 v2.1 with black scaling}{http://www.color.org}
@@ -37,12 +37,12 @@
 	%  What is it under Windows ?
 	%
 	\gdef\ColorProfileDir{/Library/Application Support/Adobe/Color/Profiles/Recommended/}
-	% 
+	%
 	%  For available profiles, see file  AdobeColorProfiles.tex
-	%  For PDF/X-4p or PDF/X-5pg   see file  AdobeExternalProfiles.tex  
+	%  For PDF/X-4p or PDF/X-5pg   see file  AdobeExternalProfiles.tex
 	%
 	%  Now you can use the macros defined in those files:
-	 \FOGRAXXXIX 
+	 \FOGRAXXXIX
 	%
 	% or CMYK is used with  PDF/X (4 parameters)
 	% \setCMYKcolorprofile{\ColorProfileDir coated_FOGRA39L_argl.icc}{Coated FOGRA39}{FOGRA39 (ISO Coated v2 300\%\space (ECI))}{http://www.color.org}
@@ -201,6 +201,7 @@
 % Allow an index to be created
 \makeindex[title=Index of Terms]
 \makeindex[name=definitions, title=Index of Definitions]
+\makeindex[name=symbols, title=Index of Symbols]
 
 
 
@@ -235,7 +236,7 @@
 	\input{contributors.tex}
 	\section*{Dedication}
 	\begin{center}
-		This book is dedicated to 
+		This book is dedicated to
 		\href{https://www.gazettetimes.com/news/local/obituaries/dr-robert-main-burton/article_9c087f07-c005-515a-bb3f-2c9c6a6b7332.html}{\color{blue}Dr.~Bob Burton}---friend and mentor.
 
 		\emph{\large ``Sometimes you have to walk the mystical path with practical feet.''}
@@ -1524,7 +1525,7 @@ argument supporting your answer.
 		\item How to express lines/planes/volumes through the origin as spans.
 		\item How to express lines/planes/volumes \emph{not} through the origin as
 			\emph{translated} spans using set addition.
-		\item Geometric and algebraic definitions of linear independence and linear 
+		\item Geometric and algebraic definitions of linear independence and linear
 			dependence.
 		\item How to find linearly independent subsets.
 	\end{itemize}
@@ -2995,7 +2996,7 @@ examples.
 	Projection of a vector onto a set, defined as the closet point in the
 	set to the vector, is a general operation used outside of linear algebra.
 	However, in the land of linear algebra, we have exact formulas for the
-	projection of a vector onto particular sets (e.g., subspaces). 
+	projection of a vector onto particular sets (e.g., subspaces).
 	Projections are a chance to explore a seemingly simple definition
 	and see it relate to sets, lines, normal form, and vector form.
 
@@ -4084,7 +4085,7 @@ examples.
 			\begin{itemize}
 				\item We are using the range of a matrix operator to describe a plane and the
 					null space of a matrix to define normal vectors.
-				\item Part 2 admits some trivial answers, but the interesting one is when 
+				\item Part 2 admits some trivial answers, but the interesting one is when
 					the range is $\mathcal P$.
 				\item For part 3, students might miss the $\vec n\neq \vec 0$ condition.
 				\item The matrices $K$ and $M$ do not have to be transposes of each other,
@@ -4891,11 +4892,11 @@ notice your group making or any questions for further pursuit.
 		\begin{notes}
 			\begin{itemize}
 				\item When talking about transformations, it is common
-					to drop the parentheses around the function argument. 
+					to drop the parentheses around the function argument.
 					E.g., $T(\vec x)\equiv T\vec x$. Point this out to students.
 				\item Part (a) is hard to write down a proof for. Don't spend so much time on it.
-				\item Spend time on the remaining parts having students write proofs. Proofs 
-					of whether something is linear follow a template. Motivate the template as: 
+				\item Spend time on the remaining parts having students write proofs. Proofs
+					of whether something is linear follow a template. Motivate the template as:
 					\emph{Start with the definitions, then write what you want. Next, write what you know.}
 					By that point, the problem is almost finished.
 			\end{itemize}
@@ -5155,7 +5156,7 @@ Suppose that the ``N'' on the left is written in regular 12-point font.  Find a 
 
 		\begin{notes}
 			\begin{itemize}
-				\item Carefully plan how to name your matrices. For example, $T$ for 
+				\item Carefully plan how to name your matrices. For example, $T$ for
 					the matrix that makes it \emph{taller} and $L$ for the matrix
 					that \emph{leans} the $N$.
 				\item Some students will have the question, ``Do we lean the taller $N$ or the original $N$?''
@@ -5420,7 +5421,7 @@ Two students---Pat and Jamie---explained their approach to italicizing the N as 
 			\begin{itemize}
 				\item These proofs have the same template as the previous subspace proofs but
 					are more abstract and so will present a new challenge to students. When
-					they are stuck, emphasize the technique: \emph{write the definitions; write what you want; 
+					they are stuck, emphasize the technique: \emph{write the definitions; write what you want;
 					write what you know.} Most will not have internalized this procedure!
 			\end{itemize}
 		\end{notes}
@@ -5532,11 +5533,11 @@ Two students---Pat and Jamie---explained their approach to italicizing the N as 
 					transformations are not the same thing. However, most will not know how to
 					create correct sentences that distinguish between matrices and linear transformations.
 
-					This problem forces the use of precise language and terminology (e.g., that of 
+					This problem forces the use of precise language and terminology (e.g., that of
 					change of basis) to discuss a matrix and its induced transformation.
 				\item Throughout most of the course, we are sloppy in distinguishing $\mat{1\\2}$ and
 					$\mat{1\\2}_{\mathcal E}$. This allows us to write $T\left(\mat{1\\2}\right)$ when $T:\R^2\to\R^2$
-					is a linear transformation (instead of the correct $T\left(\mat{1\\2}_{\mathcal E}\right)$). 
+					is a linear transformation (instead of the correct $T\left(\mat{1\\2}_{\mathcal E}\right)$).
 					
 					Acknowledge this---we will continue to be sloppy some times, but when push comes to
 					shove, we must be able to be precise.
@@ -5544,7 +5545,7 @@ Two students---Pat and Jamie---explained their approach to italicizing the N as 
 					than saying ``$T$ is the transformation given by multiplication by $M$ when
 					vectors are written in the standard basis'',
 					but both are formal and correct. We might also say, ``Consider the matrix transformation
-					$M:\R^m\to\R^n$.'' When we say this, we mean that we are using the letter $M$ 
+					$M:\R^m\to\R^n$.'' When we say this, we mean that we are using the letter $M$
 					to represent both the matrix and the induced transformation.
 			\end{itemize}
 		\end{notes}
@@ -6133,7 +6134,7 @@ Two students---Pat and Jamie---explained their approach to italicizing the N as 
 		\begin{notes}
 			\begin{itemize}
 				\item The rank-nullity theorem for matrices is easy to argue for using
-					the reduced row echelon form. The rank-nullity theorem for 
+					the reduced row echelon form. The rank-nullity theorem for
 					linear transformations is much harder to prove (unless you exploit
 					the links between transformations and their corresponding matrices).
 			\end{itemize}
@@ -6289,7 +6290,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 	\begin{annotation}
 		\begin{notes}
 			\begin{itemize}
-				\item This is the time to think about composition and ``undoing'' 
+				\item This is the time to think about composition and ``undoing''
 					transformations. In particular, the order that you undo
 					them in matters!
 				\item Plan the names of your transformations carefully. One option is to use the letters
@@ -6661,7 +6662,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 			The goal of this problem is to
 			\begin{itemize}
 				\item Create a correct formula for $(XY)^{-1}$ and
-					explain it algebraically or in terms of 
+					explain it algebraically or in terms of
 					function composition.
 				\item Relate invertibility of a matrix and its induced transformation.
 			\end{itemize}
@@ -6797,7 +6798,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 	\Heading{Motivation}
 	Change of basis is one of \emph{the} big ideas in linear algebra. The universe has no
 	privileged basis. Some bases are nicer than others, they may be orthonormal, for example, but
-	other than that, all bases are created equal. Therefore, we must understand the relationship 
+	other than that, all bases are created equal. Therefore, we must understand the relationship
 	\emph{between} bases. We need facility in converting from one basis to another. And, lo and behold,
 	converting between representations in a basis is a linear transformation!
 
@@ -7035,7 +7036,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 	\Heading{Objectives}
 	\begin{itemize}
 		\item Define the determinant as an oriented volume.
-		\item Given a linear transformation $T:\R^2\to\R^2$, 
+		\item Given a linear transformation $T:\R^2\to\R^2$,
 			compute the determinant from the definition.
 		\item Correctly extend the definition of orientation of a basis to the sign
 			of the determinant.
@@ -7194,7 +7195,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 				\item This is the first time orientation has shown up since we saw it last. Spend some
 					time explaining how orientation of a basis relates to orientation of $T(C_n)$.
 
-					It's helpful to draw an analogy with ``area under the curve'' and ``integral'' 
+					It's helpful to draw an analogy with ``area under the curve'' and ``integral''
 					from calculus. Rectangles with positive integral have sides in the $\vec e_1,\vec e_2$
 					directions (right-handed basis), and rectangles with negative integral
 					have sides in the $\vec e_1,-\vec e_2$ directions (left-handed basis).
@@ -7385,7 +7386,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 	\begin{parts}
 		\item Explain Volume Theorem I using the definition of determinant.
 			\begin{solution}
-				If $T:\R^n\to\R^n$ is a transformation with standard matrix $M=[\vec c_1|\cdots|\vec c_n]$, 
+				If $T:\R^n\to\R^n$ is a transformation with standard matrix $M=[\vec c_1|\cdots|\vec c_n]$,
 				then
 				$T(\vec e_i)$ (represented in the standard basis) will be $c_i$, the $i$th
 				column of $M$. The image of the unit cube will be a parallelepiped
@@ -7448,7 +7449,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 	The first theorem is proved because, for a matrix $A$, we have $A=X\!\Rref(A)$ where $X$ is the product of elementary matrices.
 	If $\Rref(A)\neq I$, the matrix cannot be invertible and $\det(A)=0$. If $\Rref(A)=I$, then $\det(A)\neq 0$.
 
-	The second theorem follows by noticing that if $E$ is an elementary matrix, $E^T$ is an elementary matrix 
+	The second theorem follows by noticing that if $E$ is an elementary matrix, $E^T$ is an elementary matrix
 	of the same type and it changes volume by the same amount. Thus, by decomposing $A$ as a product of elementary
 	matrices (assume it is invertible), we see $\det(A)=\det(A^T)$.
 
@@ -7476,7 +7477,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 					the volume of $T(X)$ given that you know the volume of $X$.
 
 					The argument comes from calculus: if we can show it works
-					for translated and scaled copies of $C_n$, it works for any 
+					for translated and scaled copies of $C_n$, it works for any
 					reasonable shape.
 
 					The pieces of this argument are there, but it isn't put together.
@@ -7530,13 +7531,13 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 		\item Compute the oriented volume of $M(R_1)$, $M(R_2)$, and $M(R)$.
 			\begin{solution}
 				The oriented volumes of $M(R_1)$ and $M(R_2)$ are $\tfrac{1}{2}$ and the oriented volume of
-				$M(R)$ is $2$. 
+				$M(R)$ is $2$.
 			\end{solution}
 		\item Do you have enough information to compute the oriented volume of $T(R_2)$? What about the oriented volume of $T(R+\Set{\yhat})$?
 			\begin{solution}
 				Yes. The oriented volume of $T(R_2)=\tfrac{1}{2}$ and the oriented volume of $T(R+\Set{\vec e_2})=2$.
 				
-				We don't have enough information to determine what $T(R_2)$ looks like, but we do know (i) $T(R_2)$ 
+				We don't have enough information to determine what $T(R_2)$ looks like, but we do know (i) $T(R_2)$
 				will be a parallelogram, (ii) $T(R)$ has oriented volume $2$, and (iii) $T(R)$ is made of
 				four translated copies of $T(R_2)$. From this we deduce that the oriented volume of $T(R_2)=\tfrac{1}{4}\big($oriented
 				volume of $T(R)\big)=(\tfrac{1}{4})(2)$.
@@ -7655,7 +7656,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 				\item In part 1, give the hint, ``imagine that you decomposed
 					$U$ into the product of elementary matrices. What types of
 					elementary matrices would you need?''
-				\item For part 1, a good way to to explain it is by explaining that 
+				\item For part 1, a good way to to explain it is by explaining that
 					reducing $U$ to a diagonal matrix won't affect the determinant.
 					Now reason geometrically about a diagonal matrix.
 				\item For part 2, argue algebraically: there is a matrix $R$ so $V=R\Rref(V)$.
@@ -7692,7 +7693,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 
 		\begin{notes}
 			\begin{itemize}
-				\item For part 1, emphasize the geometry first: if 
+				\item For part 1, emphasize the geometry first: if
 					the columns are linearly dependent they will
 					specify a ``flattened'' parallelepiped, which must have zero volume.
 
@@ -7727,7 +7728,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 			The goal of this problem is to
 			\begin{itemize}
 				\item Produce the determinant of $X^{-1}$ give the determinant of $X$.
-				\item Explain why a transformation $T$ is invertible if and only if 
+				\item Explain why a transformation $T$ is invertible if and only if
 					$\det(T)\neq 0$.
 			\end{itemize}
 		\end{goals}
@@ -7808,7 +7809,7 @@ Pat and Jamie explained their approach to the Italicizing N task as follows:
 \addcontentsline{toc}{subsection}{The Green and the Black}
 
 \question
-The subway system of Oronto is laid out in a skewed grid. All tracks run parallel to one of the 
+The subway system of Oronto is laid out in a skewed grid. All tracks run parallel to one of the
 green lines shown. Compass directions are given by the black lines.
 
 While studying the subway map, you decide to pick two bases to help:
@@ -7933,7 +7934,7 @@ While studying the subway map, you decide to pick two bases to help:
 	properties of eigenvectors/values one step at a time.
 
 	As we've already seen, if $\vec v$ is an eigenvector for $A$, then $A\vec v$ is easy to compute.
-	It's less obvious to students that $(A+tI)\vec v$ is equally easy to compute. 
+	It's less obvious to students that $(A+tI)\vec v$ is equally easy to compute.
 	The algorithm for
 	finding eigenvectors/values relies on (i) our ability to compute the null space of $A-\lambda I$,
 	and (ii) our ability to algorithmically determine if $A-\lambda I$ is invertible. In this lesson we
@@ -8155,9 +8156,9 @@ While studying the subway map, you decide to pick two bases to help:
 		\item For what values of $\lambda$ does $E_\lambda$ have a non-trivial
 			null space?
 			\begin{solution}
-				$\lambda=-2$ and $\lambda=1$. 
+				$\lambda=-2$ and $\lambda=1$.
 
-				$E_\lambda$ has a non-trivial null space exactly when its 
+				$E_\lambda$ has a non-trivial null space exactly when its
 				determinant is zero. We compute:
 				\[
 					\det(E_\lambda)
@@ -8186,12 +8187,12 @@ While studying the subway map, you decide to pick two bases to help:
 				multiples of these).
 
 				We know from the previous part that finding an eigenvector with
-				corresponding eigenvalue $-2$ amounts to finding the non-zero 
-				vectors	in the null space of  
+				corresponding eigenvalue $-2$ amounts to finding the non-zero
+				vectors	in the null space of
 				$E_{-2}=\mat{1&2\\1&2}$. Computing,
 				\[\Null(E_{-2})=\Span\Set*{\mat{-2\\1}}.\]
 				Similarly, the eigenvectors with corresponding eigenvalue $1$ are
-				the non-zero vectors in the null space of $E_1=\mat{-2&2\\1&-1}$, 
+				the non-zero vectors in the null space of $E_1=\mat{-2&2\\1&-1}$,
 				and we compute that $\Null(E_1)=\Span\Set*{\mat{1\\1}}$.
 			\end{solution}
 	\end{parts}
@@ -8285,7 +8286,7 @@ While studying the subway map, you decide to pick two bases to help:
 	\begin{parts}
 		\item Compute $\chr(D)$.
 			\begin{solution}
-				$\chr(D)=(-2-\lambda)(3-\lambda)$. 
+				$\chr(D)=(-2-\lambda)(3-\lambda)$.
 
 				We compute:
 				\[
@@ -8298,8 +8299,8 @@ While studying the subway map, you decide to pick two bases to help:
 			\end{solution}
 		\item Find the eigenvalues of $D$.
 			\begin{solution}
-				The eigenvalues of $D$ are $-2$ and $3$. 
-				The eigenvalues of $D$ are the roots of $\chr(D)$. 
+				The eigenvalues of $D$ are $-2$ and $3$.
+				The eigenvalues of $D$ are the roots of $\chr(D)$.
 			\end{solution}
 	\end{parts}
 
@@ -8329,7 +8330,7 @@ While studying the subway map, you decide to pick two bases to help:
 					This part also requires a lot of sophistication to pin down.
 					It's easy to argue that the appropriate nullities will be $\geq 1$
 					and $<3$, but arguing that they are equal to $1$ (and not $2$) takes work.
-					Don't bother completing the argument pinning down the exact nullities 
+					Don't bother completing the argument pinning down the exact nullities
 					(but feel free to tell them the exact nullities).
 			\end{itemize}
 		\end{notes}
@@ -8340,17 +8341,17 @@ While studying the subway map, you decide to pick two bases to help:
 	\begin{parts}
 		\item What are the eigenvalues of $E$?
 			\begin{solution}
-				$0$, $2$, and $-3$. 
+				$0$, $2$, and $-3$.
 
-				The eigenvalues of $E$ are the roots of $\chr(E)$. 
+				The eigenvalues of $E$ are the roots of $\chr(E)$.
 			\end{solution}
 		\item Is $E$ invertible?
 			\begin{solution}
-				No. 
+				No.
 
 				Since $0$ is an eigenvalue of $E$, there must be a non-zero vector
 				$\vec v$ such that $E\vec v=0\vec v=\vec 0$. This means $\Nullity(E)>0$,
-				which implies $E$ is not invertible. 
+				which implies $E$ is not invertible.
 			\end{solution}
 		\item What can you say about $\Nullity(E)$, $\Nullity(E-3I)$, $\Nullity(E+3I)$?
 			\begin{solution}
@@ -8366,7 +8367,7 @@ While studying the subway map, you decide to pick two bases to help:
 
 				To pin down the nullities of $E$ and $E+3I$ exactly takes more work.
 				$E$ has three distinct eigenvalues and so $E$ must have three linearly
-				independent eigenvectors $\vec v_0,\vec v_2,\vec v_{-3}$. Further, $\Span\Set{\vec v_i}\subseteq 
+				independent eigenvectors $\vec v_0,\vec v_2,\vec v_{-3}$. Further, $\Span\Set{\vec v_i}\subseteq
 				\Null(E-\lambda_i I)$.				
 				Since $\vec v_0,\vec v_1,\vec v_{-3}\in\R^3$, it must be the case that $\Null(E-\lambda_i I)$ is one
 				dimensional for $i\in\Set{0,2,-3}$.
@@ -8542,8 +8543,8 @@ While studying the subway map, you decide to pick two bases to help:
 			\begin{solution}
 				Computing $[T_A]_{\mathcal V}[\vec y]_{\mathcal V}$ is easy, since
 				$[T_A]_{\mathcal V}$ just multiplies each coordinate of $[\vec y]_{\mathcal V}$
-				by a scalar. We know that $P^{-1}[\vec y]_{\mathcal E}=[\vec y]_{\mathcal V}$ 
-				and that $P[\vec x]_{\mathcal V}=[\vec x]_{\mathcal E}$ and so 
+				by a scalar. We know that $P^{-1}[\vec y]_{\mathcal E}=[\vec y]_{\mathcal V}$
+				and that $P[\vec x]_{\mathcal V}=[\vec x]_{\mathcal E}$ and so
 				given any vector $\vec v$ represented by $[\vec v]_{\mathcal E}$
 				in the standard basis, we have
 				\[
@@ -8635,11 +8636,11 @@ While studying the subway map, you decide to pick two bases to help:
 		\end{solution}
 		\item Is $B$ diagonalizable (i.e., similar to a diagonal matrix)?  If so, explain how to obtain its diagonalized form.
 		\begin{solution}
-			Yes. 
+			Yes.
 
 			$\mathcal V=\Set{\vec v_1,\ldots \vec v_n}$ is a basis consisting
 			of eigenvectors for $T_B$. By definition, $B[\vec v_i]_{\mathcal E}=\lambda_i[\vec v_i]_{\mathcal E}$
-			for each $i$. 
+			for each $i$.
 
 			Let $P$ be the matrix that takes vectors represented in the
 			$\mathcal V$ basis and outputs their representations in the standard
@@ -8654,14 +8655,14 @@ While studying the subway map, you decide to pick two bases to help:
 			\]
 			Therefore, the first column of $P^{-1}BP$ is $\matc{\lambda_1\\0\\\vdots\\0}$.
 			By similar reasoning, the $i^\text{th}$ column of $P^{-1}BP$ consists
-			of all zeroes except for $\lambda_i$ in the $i^\text{th}$ position. 
-			In other words, $B$ is similar to the diagonal matrix $D$ with 
+			of all zeroes except for $\lambda_i$ in the $i^\text{th}$ position.
+			In other words, $B$ is similar to the diagonal matrix $D$ with
 			$\lambda_1, \lambda_2, \dots, \lambda_n$ along the diagonal, in that
-			order. 
+			order.
 		\end{solution}
 		\item What if one of the eigenvalues of $T_B$ is zero?  Would $B$ be diagonalizable?
 			\begin{solution}
-				Yes. 
+				Yes.
 
 				The argument in the previous part does not depend on any of the
 				eigenvalues being non-zero.
@@ -8669,13 +8670,13 @@ While studying the subway map, you decide to pick two bases to help:
 		\item What if the eigenvectors of $T_B$ did not form a basis for $\R^n$.
 			Would $B$ be diagonalizable?
 			\begin{solution}
-				No. 
+				No.
 
 				The argument we used in the first part definitely would not work.
 
-				Consider the converse, and assume $B$ is similar to diagonal 
-				matrix $D$. That is, suppose there is an invertible matrix 
-				$P$ such that $B=PDP^{-1}$. Then, if $\vec v_1$ is the first 
+				Consider the converse, and assume $B$ is similar to diagonal
+				matrix $D$. That is, suppose there is an invertible matrix
+				$P$ such that $B=PDP^{-1}$. Then, if $\vec v_1$ is the first
 				column of $P$ and $\lambda_1$ is the first entry on	the diagonal
 				of $D$, we would have
 				\[
@@ -8688,10 +8689,10 @@ While studying the subway map, you decide to pick two bases to help:
 				\]
 				meaning that $[\vec v_1]_{\mathcal E}$ is an eigenvector of $B$. Similarly, all
 				of the columns of $P$ would be eigenvectors of $B$, with eigenvalues
-				equal to the corresponding entry on the diagonal of $D$. Since $P$ is 
+				equal to the corresponding entry on the diagonal of $D$. Since $P$ is
 				invertible, its columns must be linearly independent, and therefore
 				the $n$ columns of $P$ would form a basis of $\R^n$ consisting of
-				eigenvectors of $B$. 
+				eigenvectors of $B$.
 			\end{solution}
 	\end{parts}
 
@@ -8752,7 +8753,7 @@ While studying the subway map, you decide to pick two bases to help:
 				\item The explanation for part 3 depends on whether you allow complex numbers.
 					If you allow complex numbers, then $\sum$ algebraic multiplicities = dim
 					of space. If not, it's $\leq$ dim of space. In either case, geometric
-					multiplicity $<$ algebraic multiplicity implies not diagonalizable. 
+					multiplicity $<$ algebraic multiplicity implies not diagonalizable.
 					But only in the case of an algebraically closed field do you get
 					converse.
 				\item If you like, you can bring up an example of a rotation that has non-real
@@ -8769,16 +8770,16 @@ While studying the subway map, you decide to pick two bases to help:
 				$F$ is diagonalizable if and only if there is a basis of $\R^2$
 				consisting of eigenvectors of $F$, so we begin by computing all
 				eigenvectors of $F$.
-				$\chr(F)=(3-\lambda)^2$, so the only eigenvalue of $F$ is $3$, 
+				$\chr(F)=(3-\lambda)^2$, so the only eigenvalue of $F$ is $3$,
 				meaning that the eigenvectors of $F$ are precisely the non-zero
-				vectors in $\Null(F-3I)$. We check that 
+				vectors in $\Null(F-3I)$. We check that
 				\[
 					\Null(F-3I)
 					=\Null\left(\mat{0&1\\0&0}\right)
 					=\Span\Set*{\mat{1\\0}},
 				\]
 				which is one-dimensional, and so there cannot be a basis of $\R^2$
-				consisting of eigenvectors of $F$. 
+				consisting of eigenvectors of $F$.
 			\end{solution}
 		\item Is $G$ diagonalizable?  Why or why not?
 			\begin{solution}
@@ -8787,8 +8788,8 @@ While studying the subway map, you decide to pick two bases to help:
 		\item What are the geometric and algebraic multiplicities of each eigenvalue
 			of $F$? What about the multiplicities for each eigenvalue of $G$?
 			\begin{solution}
-				The only eigenvalue for $F$ is $3$. Its geometric multiplicity is $1$, 
-				and its algebraic multiplicity is $2$. 
+				The only eigenvalue for $F$ is $3$. Its geometric multiplicity is $1$,
+				and its algebraic multiplicity is $2$.
 				
 				The only eigenvalue for $G$ is $3$. Its geometric and algebraic multiplicity is $2$.
 			\end{solution}
@@ -8798,7 +8799,7 @@ While studying the subway map, you decide to pick two bases to help:
 			match?
 		\begin{solution}
 				If one of the geometric multiplicities is smaller than the corresponding
-				algebraic multiplicity, $A$ cannot be diagonalizable. 
+				algebraic multiplicity, $A$ cannot be diagonalizable.
 				
 				Since the characteristic polynomial of an $n\times n$ matrix has degree $n$,
 				it has at most $n$ real roots. Since each root is an eigenvalue, we have
@@ -8833,9 +8834,12 @@ While studying the subway map, you decide to pick two bases to help:
 	\clearpage
 	\hbox{}
 	\newpage
+	\printindex[symbols]
+	
 	\printindex
 	
 	\printindex[definitions]
+	
 \end{bookonly}
 
 

--- a/problemsets-mat223/modules/module1.tex
+++ b/problemsets-mat223/modules/module1.tex
@@ -1,5 +1,5 @@
 \Heading{Sets}
-Modern mathematics makes heavy use of \emph{sets}\index{set}.  
+Modern mathematics makes heavy use of \emph{sets}\index{Set}.  
 A set is an unordered collection of distinct objects.  We won't try and pin
 it down more than this---our intuition about collections
 of objects will suffice\footnote{ When you pursue more rigorous math,
@@ -14,9 +14,9 @@ list the objects inside.  For instance
 	\Set{1,2,3}.
 \]
 This would be read aloud as ``the set containing the elements $1$, $2$, and $3$''.
-Things in a set are called \emph{elements}\index{element of a set}\index{set!element},
-and the symbol $\in$\index{$\in$} is used to specify that something is an element of a set.
-In contrast, $\notin$\index{$\notin$} is used to specify something is not an element of a set.  For example,
+Things in a set are called \emph{elements}\index{Set!element of},
+and the symbol $\in$\index[symbols]{$\in$} is used to specify that something is an element of a set.
+In contrast, $\notin$\index[symbols]{$\notin$} is used to specify something is not an element of a set.  For example,
 \[
 	3\in\Set{1,2,3}\qquad 4\notin\Set{1,2,3}.
 \]
@@ -29,10 +29,10 @@ is a perfectly valid set.
 It is tradition to use capital letters to name sets.  So we might say $A=\{6,7,12\}$
 or $X=\{7\}$.  However there are some special sets which
 already have names/symbols associated with them.
-The \emph{empty set}\index{empty set}\index[definitions]{empty set}\index{set!empty set}\index[definitions]{set!empty set} is the set containing no elements
-and is written $\emptyset$\index{\(\emptyset\)} or $\Set{}$.  Note that $\Set{\emptyset}$ is \emph{not}
+The \emph{empty set}\index{Set!empty}\index[definitions]{Set!empty} is the set containing no elements
+and is written $\emptyset$\index[symbols]{$\emptyset$} or $\Set{}$.  Note that $\Set{\emptyset}$ is \emph{not}
 the empty set---it is the set containing the empty set!  It is also traditional
-to call elements of a set \emph{points}\index{point} regardless of whether you
+to call elements of a set \emph{points}\index{Point} regardless of whether you
 consider them ``point-like''.
 
 \Heading{Operations on Sets}
@@ -72,7 +72,7 @@ Having a definition of equality to lean on will help us when we need to prove th
 
 \Heading{Set-builder Notation}
 Specifying sets by listing all their elements can be a hassle, and if there are an infinite
-number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{set!set-builder notation}\index{set-builder notation}
+number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{Set-builder notation}\index{Set-builder notation}
 solves these problems.
 If $X$ is a set, we can define a subset 
 \[
@@ -82,7 +82,7 @@ which is read ``$Y$ is the set of $a$ in $X$ \emph{such that} some rule
 involving $a$ is true.''  If $X$ is intuitive, we may omit it and
 simply write $Y=\Set{a\given\text{some rule involving }a}$\footnote{ If you want
 to get technical, to make this notation unambiguous, you define a 
-\emph{universe of discourse}\index{universe of discourse}.  That is, a set $\mathcal U$ containing
+\emph{universe of discourse}\index{Universe of discourse}.  That is, a set $\mathcal U$ containing
 every object you might want to talk about.  Then $\Set{a\given\text{some rule involving }a}$
 is short for $\Set{a\in\mathcal U\given\text{some rule involving }a}$}.  You may equivalently
 use ``$|$'' instead of ``$:$'', writing $Y=\{a\,|\,\text{some rule involving }a\}$.
@@ -103,23 +103,23 @@ different than $A\cup(B\cap C)$!
 Some common sets have special notation:
 \begin{align*}
 	\emptyset &= \Set{}\text{, the empty set}\\
-	\N\index{\(\N\)} &= \Set{0,1,2,3,\ldots}=\Set{\text{natural numbers}}\\
-	\Z\index{\(\Z\)} &= \Set{\ldots, -3,-2,-1,0,1,2,3,\ldots}=\Set{\text{integers}}\\
-	\Q\index{\(\Q\)} &= \Set{\text{rational numbers}}\\
-	\R\index{\(\R\)} &= \Set{\text{real numbers}}\\
-	\R^n\index{\(\R^n\)} &= \Set{\text{vectors in $n$-dimensional Euclidean space}}\\
+	\N\index[symbols]{$\N$} &= \Set{0,1,2,3,\ldots}=\Set{\text{natural numbers}}\\
+	\Z\index[symbols]{$\Z$} &= \Set{\ldots, -3,-2,-1,0,1,2,3,\ldots}=\Set{\text{integers}}\\
+	\Q\index[symbols]{$\Q$} &= \Set{\text{rational numbers}}\\
+	\R\index[symbols]{$\R$} &= \Set{\text{real numbers}}\\
+	\R^n\index[symbols]{$\R^n$} &= \Set{\text{vectors in $n$-dimensional Euclidean space}}\\
 \end{align*}
 
 
 
 \Heading{Vectors \& Scalars}
-A \emph{scalar}\index{scalar}\index[definitions]{scalar} number (also referred to as a \emph{scalar} or just an ordinary
+A \emph{scalar}\index{Scalar}\index[definitions]{Scalar} number (also referred to as a \emph{scalar} or just an ordinary
 \emph{number}) models a relationship between quantities. For example,
 a recipe might call for \emph{six} times as much flour as sugar. In 
-contrast, a \emph{vector}\index{vector}\index[definitions]{vector} models a relationship between points. For example,
+contrast, a \emph{vector}\index{Vector}\index[definitions]{Vector} models a relationship between points. For example,
 the store might be \emph{2km East and 4km North} from your house.
-In this way, a vector may be thought of as a \emph{displacement} with a \emph{direction}\index{direction}\index{vector!direction}
-and a \emph{magnitude}\index{vector!magnitude}\index{magnitude}\footnote{
+In this way, a vector may be thought of as a \emph{displacement} with a \emph{direction}\index{Vector!direction of}
+and a \emph{magnitude}\index{Vector!magnitude of}\footnote{
 	Though in this book we will treat vectors as geometric objects 
 	relating to Euclidean
 	space, they are much more general.  For instance, someone's internet
@@ -129,7 +129,7 @@ and a \emph{magnitude}\index{vector!magnitude}\index{magnitude}\footnote{
 }.
 
 Given points $P=(1,1)$ and $Q=(3,2)$, we specify the
-\emph{displacement}\index{displacement} from $P$ to $Q$ as a vector
+\emph{displacement}\index{Displacement} from $P$ to $Q$ as a vector
 $\overrightarrow{PQ}$ whose magnitude is $\sqrt{5}$ (as given by the Pythagorean
 theorem) and whose direction is specified by a directed line segment from $P$ to $Q$.
 
@@ -173,13 +173,13 @@ vector from $P$ to $Q$.  Absent points, a bold-faced letter (like {\bfseries a})
 or an arrow over 
 a letter (like $\vec a$) are the most common vector notations.
 In this text, we will use $\vec a$ to represent a vector.
-The notation $\norm{\vec a}$\index{$\norm{\:\cdot\:}$}\index{vector!magnitude}\index{vector!norm}\index{magnitude}\index{norm}
+The notation $\norm{\vec a}$\index[symbols]{$\norm{\:\cdot\:}$}\index{Vector!magnitude of}\index{Vector!norm of}
 represents the magnitude of the vector $\vec a$, which is sometimes called
 the \emph{norm} or \emph{length} of $\vec a$.
 
 
 Graphically, we may represent vectors as directed line segments (a
-line segment with an arrow at one end)\index{directed line segment}, however we must take care to
+line segment with an arrow at one end), however we must take care to
 distinguish between the picture we draw and the ``true'' vector.
 For example, directed line segments always \emph{start} somewhere, but a vector
 models a displacement and has no sense of ``origin''.
@@ -221,7 +221,7 @@ the same or different vectors?  As directed line segments,
 they are different because they are at different locations in space.  
 However, both $\vec a$ and $\vec x$ have the same
 magnitude and direction.  Thus, $\vec a=\vec x$ despite the fact that $A\neq X$\footnote{
-	Some theories use \emph{rooted vectors}\index{vector!rooted}\index{rooted vector} instead of
+	Some theories use \emph{rooted vectors}\index{Vector!rooted} instead of
 	vectors as the fundamental object of study. A rooted vector
 	represents a magnitude, direction, \emph{and} a starting point. And, 
 	as rooted vectors, $\vec a\neq \vec x$ (from the example above).
@@ -236,14 +236,14 @@ magnitude and direction.  Thus, $\vec a=\vec x$ despite the fact that $A\neq X$\
 
 \Heading{Vectors and Points}
 The distinction between vectors and points is sometimes nebulous because
-the two are so closely related.  A \emph{point}\index{point}
+the two are so closely related.  A \emph{point}\index{Point!in Euclidean Space}
 in Euclidean space specifies an absolute position whereas a vector
 specifies a displacement (i.e., a magnitude and direction).  However, given a point $P$,
 one associates $P$ with the vector $\vec p=\overrightarrow{OP}$, where $O$
 is the origin.  Similarly, we associate the vector $\vec v$ with
 the point $V$ so that $\overrightarrow{OV}=\vec v$.
 Thus, we have a way to unambiguously go back and forth between vectors and
-points\footnote{ Mathematically, we say there is an \emph{isomorphism}\index{isomorphism} between
+points\footnote{ Mathematically, we say there is an \emph{isomorphism}\index{Isomorphism} between
 vectors and points (once an origin is fixed, of course!).}.  As such, \emph{we will treat vectors and points
 interchangeably}.
 
@@ -280,7 +280,7 @@ for any scalar $\alpha$ and any vectors
 $\vec v$ and $\vec w$, we could
 do algebra with vectors.
 
-We will define scalar multiplication\index[definitions]{vector!scalar multiplication}\index{vector!scalar multiplication}\index[definitions]{scalar multiplication}\index{scalar multiplication} and vector addition\index[definitions]{vector!addition}\index{vector!addition}\index[definitions]{vector addition}\index{vector addition} intuitively:
+We will define scalar multiplication\index[definitions]{Vector operations!scalar multiplication}\index{Vector operations!scalar multiplication}\index{Vector operations!addition}\index{Vector operations!addition} intuitively:
 For a vector $\vec v$ and a scalar $\alpha>0$, the
 vector $\vec w=\alpha\vec v$ is the vector pointing in the same direction as
 $\vec v$ but with length scaled by $\alpha$.  That is, $\norm{\vec w}=\alpha\norm{\vec v}$.
@@ -340,9 +340,9 @@ never talk about \emph{the} direction of the zero vector, since it's not defined
 Formalizing, for vectors $\vec u$, $\vec v$, $\vec w$, and scalars $\alpha$ and $\beta$, the
 following laws are always satisfied:
 \begin{align*}
-	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity\index{associativity}}\\
-	\vec u+\vec v&=\vec v+\vec u\tag{Commutativity\index{commutativity}}\\
-	\alpha(\vec u+\vec v)&=\alpha\vec u+\alpha \vec v\tag{Distributivity\index{distributivity}}
+	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity\index{Vector operations!laws of}}\\
+	\vec u+\vec v&=\vec v+\vec u\tag{Commutativity}\\
+	\alpha(\vec u+\vec v)&=\alpha\vec u+\alpha \vec v\tag{Distributivity}
 \end{align*}
 and
 \begin{align*}
@@ -423,7 +423,7 @@ there is one standard one: the $xy$-coordinate system depicted below (which you'
 	\end{tikzpicture}
 \end{center}
 
-In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}\index[definitions]{standard basis vectors}\index{standard basis vectors}\index[definitions]{vector!standard basis}\index{vector!standard basis}.
+In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}\index[definitions]{Standard basis}\index{Standard basis}\index[definitions]{Basis!standard basis}\index{Basis!standard basis}.
 The vector $\xhat$ always points one unit in the direction of the positive $x$-axis and $\yhat$
 always points one unit in the direction of the positive $y$-axis.
 
@@ -439,7 +439,7 @@ $\alpha$ and $\beta$.
 
 For a vector $\vec w=\alpha\xhat+\beta\yhat$,
 we call the pair $(\alpha,\beta)$  the
-\emph{standard coordinates}\index{coordinates} of the vector $\vec w$.  There
+\emph{standard coordinates}\index{Coordinates} of the vector $\vec w$.  There
 are many equivalent notations used to represent a vector in coordinates.
 \begin{center}
 	\begin{tabular}{c p{7cm}}

--- a/problemsets-mat223/modules/module1.tex
+++ b/problemsets-mat223/modules/module1.tex
@@ -6,7 +6,7 @@ of objects will suffice\footnote{ When you pursue more rigorous math,
 you rely on definitions to get yourself out of philosophical jams.  For instance,
 with our definition of set, consider ``the set of all sets that don't
 contain themselves''.  Such a set cannot exist!
-This is called \emph{Russel's Paradox}, and shows
+This is called \emph{Russel's Paradox}\index{Russel's Paradox}, and shows
 that if we start talking about sets of sets, we may need more than
 intuition.}. We write a set with curly-braces $\{$ and $\}$ and
 list the objects inside.  For instance
@@ -14,9 +14,9 @@ list the objects inside.  For instance
 	\Set{1,2,3}.
 \]
 This would be read aloud as ``the set containing the elements $1$, $2$, and $3$''.
-Things in a set are called \emph{elements}\index{element of a set},
+Things in a set are called \emph{elements}\index{element of a set}\index{set!element},
 and the symbol $\in$\index{$\in$} is used to specify that something is an element of a set.
-In contrast, $\notin$ is used to specify something is not an element of a set.  For example,
+In contrast, $\notin$\index{$\notin$} is used to specify something is not an element of a set.  For example,
 \[
 	3\in\Set{1,2,3}\qquad 4\notin\Set{1,2,3}.
 \]
@@ -29,15 +29,15 @@ is a perfectly valid set.
 It is tradition to use capital letters to name sets.  So we might say $A=\{6,7,12\}$
 or $X=\{7\}$.  However there are some special sets which
 already have names/symbols associated with them.
-The \emph{empty set} is the set containing no elements
-and is written $\emptyset$ or $\Set{}$.  Note that $\Set{\emptyset}$ is \emph{not}
+The \emph{empty set}\index{empty set}\index[definitions]{empty set}\index{set!empty set}\index[definitions]{set!empty set} is the set containing no elements
+and is written $\emptyset$\index{\(\emptyset\)} or $\Set{}$.  Note that $\Set{\emptyset}$ is \emph{not}
 the empty set---it is the set containing the empty set!  It is also traditional
 to call elements of a set \emph{points}\index{point} regardless of whether you
 consider them ``point-like''.
 
 \Heading{Operations on Sets}
-If the set $A$ contains all the elements that the set $B$ does, we call $B$ a \emph{subset}\index{subset}
-of $A$. Conversely, we call $A$ a \emph{superset}\index{superset} of $B$.  
+If the set $A$ contains all the elements that the set $B$ does, we call $B$ a \emph{subset}
+of $A$. Conversely, we call $A$ a \emph{superset} of $B$.  
 \SavedDefinitionRender{SubsetSuperset}
 
 Some simple examples are $\Set{1,2,3}\subseteq \Set{1,2,3,4}$ and $\Set{1,2,3}\subseteq\Set{1,2,3}$.
@@ -72,7 +72,7 @@ Having a definition of equality to lean on will help us when we need to prove th
 
 \Heading{Set-builder Notation}
 Specifying sets by listing all their elements can be a hassle, and if there are an infinite
-number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{set-builder notation}
+number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{set!set-builder notation}\index{set-builder notation}
 solves these problems.
 If $X$ is a set, we can define a subset 
 \[
@@ -82,7 +82,7 @@ which is read ``$Y$ is the set of $a$ in $X$ \emph{such that} some rule
 involving $a$ is true.''  If $X$ is intuitive, we may omit it and
 simply write $Y=\Set{a\given\text{some rule involving }a}$\footnote{ If you want
 to get technical, to make this notation unambiguous, you define a 
-\emph{universe of discourse}.  That is, a set $\mathcal U$ containing
+\emph{universe of discourse}\index{universe of discourse}.  That is, a set $\mathcal U$ containing
 every object you might want to talk about.  Then $\Set{a\given\text{some rule involving }a}$
 is short for $\Set{a\in\mathcal U\given\text{some rule involving }a}$}.  You may equivalently
 use ``$|$'' instead of ``$:$'', writing $Y=\{a\,|\,\text{some rule involving }a\}$.
@@ -103,23 +103,23 @@ different than $A\cup(B\cap C)$!
 Some common sets have special notation:
 \begin{align*}
 	\emptyset &= \Set{}\text{, the empty set}\\
-	\N &= \Set{0,1,2,3,\ldots}=\Set{\text{natural numbers}}\\
-	\Z &= \Set{\ldots, -3,-2,-1,0,1,2,3,\ldots}=\Set{\text{integers}}\\
-	\Q &= \Set{\text{rational numbers}}\\
-	\R &= \Set{\text{real numbers}}\\
-	\R^n &= \Set{\text{vectors in $n$-dimensional Euclidean space}}\\
+	\N\index{\(\N\)} &= \Set{0,1,2,3,\ldots}=\Set{\text{natural numbers}}\\
+	\Z\index{\(\Z\)} &= \Set{\ldots, -3,-2,-1,0,1,2,3,\ldots}=\Set{\text{integers}}\\
+	\Q\index{\(\Q\)} &= \Set{\text{rational numbers}}\\
+	\R\index{\(\R\)} &= \Set{\text{real numbers}}\\
+	\R^n\index{\(\R^n\)} &= \Set{\text{vectors in $n$-dimensional Euclidean space}}\\
 \end{align*}
 
 
 
 \Heading{Vectors \& Scalars}
-A \emph{scalar} number (also referred to as a \emph{scalar} or just an ordinary
+A \emph{scalar}\index{scalar}\index[definitions]{scalar} number (also referred to as a \emph{scalar} or just an ordinary
 \emph{number}) models a relationship between quantities. For example,
 a recipe might call for \emph{six} times as much flour as sugar. In 
-contrast, a \emph{vector} models a relationship between points. For example,
+contrast, a \emph{vector}\index{vector}\index[definitions]{vector} models a relationship between points. For example,
 the store might be \emph{2km East and 4km North} from your house.
-In this way, a vector may be thought of as a \emph{displacement} with a \emph{direction}
-and a \emph{magnitude}\footnote{
+In this way, a vector may be thought of as a \emph{displacement} with a \emph{direction}\index{direction}\index{vector!direction}
+and a \emph{magnitude}\index{vector!magnitude}\index{magnitude}\footnote{
 	Though in this book we will treat vectors as geometric objects 
 	relating to Euclidean
 	space, they are much more general.  For instance, someone's internet
@@ -173,13 +173,13 @@ vector from $P$ to $Q$.  Absent points, a bold-faced letter (like {\bfseries a})
 or an arrow over 
 a letter (like $\vec a$) are the most common vector notations.
 In this text, we will use $\vec a$ to represent a vector.
-The notation $\norm{\vec a}$\index{$\norm{\:\cdot\:}$}\index{magnitude}\index{norm}
+The notation $\norm{\vec a}$\index{$\norm{\:\cdot\:}$}\index{vector!magnitude}\index{vector!norm}\index{magnitude}\index{norm}
 represents the magnitude of the vector $\vec a$, which is sometimes called
 the \emph{norm} or \emph{length} of $\vec a$.
 
 
 Graphically, we may represent vectors as directed line segments (a
-line segment with an arrow at one end), however we must take care to
+line segment with an arrow at one end)\index{directed line segment}, however we must take care to
 distinguish between the picture we draw and the ``true'' vector.
 For example, directed line segments always \emph{start} somewhere, but a vector
 models a displacement and has no sense of ``origin''.
@@ -221,7 +221,7 @@ the same or different vectors?  As directed line segments,
 they are different because they are at different locations in space.  
 However, both $\vec a$ and $\vec x$ have the same
 magnitude and direction.  Thus, $\vec a=\vec x$ despite the fact that $A\neq X$\footnote{
-	Some theories use \emph{rooted vectors}\index{rooted vector} instead of
+	Some theories use \emph{rooted vectors}\index{vector!rooted}\index{rooted vector} instead of
 	vectors as the fundamental object of study. A rooted vector
 	represents a magnitude, direction, \emph{and} a starting point. And, 
 	as rooted vectors, $\vec a\neq \vec x$ (from the example above).
@@ -243,7 +243,7 @@ one associates $P$ with the vector $\vec p=\overrightarrow{OP}$, where $O$
 is the origin.  Similarly, we associate the vector $\vec v$ with
 the point $V$ so that $\overrightarrow{OV}=\vec v$.
 Thus, we have a way to unambiguously go back and forth between vectors and
-points\footnote{ Mathematically, we say there is an \emph{isomorphism} between
+points\footnote{ Mathematically, we say there is an \emph{isomorphism}\index{isomorphism} between
 vectors and points (once an origin is fixed, of course!).}.  As such, \emph{we will treat vectors and points
 interchangeably}.
 
@@ -280,7 +280,7 @@ for any scalar $\alpha$ and any vectors
 $\vec v$ and $\vec w$, we could
 do algebra with vectors.
 
-We will define scalar multiplication and vector addition intuitively:
+We will define scalar multiplication\index[definitions]{vector!scalar multiplication}\index{vector!scalar multiplication}\index[definitions]{scalar multiplication}\index{scalar multiplication} and vector addition\index[definitions]{vector!addition}\index{vector!addition}\index[definitions]{vector addition}\index{vector addition} intuitively:
 For a vector $\vec v$ and a scalar $\alpha>0$, the
 vector $\vec w=\alpha\vec v$ is the vector pointing in the same direction as
 $\vec v$ but with length scaled by $\alpha$.  That is, $\norm{\vec w}=\alpha\norm{\vec v}$.
@@ -340,9 +340,9 @@ never talk about \emph{the} direction of the zero vector, since it's not defined
 Formalizing, for vectors $\vec u$, $\vec v$, $\vec w$, and scalars $\alpha$ and $\beta$, the
 following laws are always satisfied:
 \begin{align*}
-	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity}\\
-	\vec u+\vec v&=\vec v+\vec u\tag{Commutativity}\\
-	\alpha(\vec u+\vec v)&=\alpha\vec u+\alpha \vec v\tag{Distributivity}
+	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity\index{associativity}}\\
+	\vec u+\vec v&=\vec v+\vec u\tag{Commutativity\index{commutativity}}\\
+	\alpha(\vec u+\vec v)&=\alpha\vec u+\alpha \vec v\tag{Distributivity\index{distributivity}}
 \end{align*}
 and
 \begin{align*}
@@ -423,7 +423,7 @@ there is one standard one: the $xy$-coordinate system depicted below (which you'
 	\end{tikzpicture}
 \end{center}
 
-In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}.
+In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}\index[definitions]{standard basis vectors}\index{standard basis vectors}\index[definitions]{vector!standard basis}\index{vector!standard basis}.
 The vector $\xhat$ always points one unit in the direction of the positive $x$-axis and $\yhat$
 always points one unit in the direction of the positive $y$-axis.
 

--- a/problemsets-mat223/modules/module1.tex
+++ b/problemsets-mat223/modules/module1.tex
@@ -32,7 +32,7 @@ already have names/symbols associated with them.
 The \emph{empty set}\index{Set!empty}\index[definitions]{Set!empty} is the set containing no elements
 and is written $\emptyset$\index[symbols]{$\emptyset$} or $\Set{}$.  Note that $\Set{\emptyset}$ is \emph{not}
 the empty set---it is the set containing the empty set!  It is also traditional
-to call elements of a set \emph{points}\index{Point} regardless of whether you
+to call elements of a set \emph{points}\index{Point!of a set} regardless of whether you
 consider them ``point-like''.
 
 \Heading{Operations on Sets}

--- a/problemsets-mat223/modules/module1.tex
+++ b/problemsets-mat223/modules/module1.tex
@@ -1,5 +1,5 @@
 \Heading{Sets}
-Modern mathematics makes heavy use of \emph{sets}\index{Set}.  
+Modern mathematics makes heavy use of \emph{sets}.  
 A set is an unordered collection of distinct objects.  We won't try and pin
 it down more than this---our intuition about collections
 of objects will suffice\footnote{ When you pursue more rigorous math,
@@ -340,10 +340,10 @@ never talk about \emph{the} direction of the zero vector, since it's not defined
 Formalizing, for vectors $\vec u$, $\vec v$, $\vec w$, and scalars $\alpha$ and $\beta$, the
 following laws are always satisfied:
 \begin{align*}
-	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity\index{Vector operations!laws of}}\\
+	(\vec u+\vec v)+\vec w&=\vec u+(\vec v+\vec w)\tag{Associativity}\\
 	\vec u+\vec v&=\vec v+\vec u\tag{Commutativity}\\
 	\alpha(\vec u+\vec v)&=\alpha\vec u+\alpha \vec v\tag{Distributivity}
-\end{align*}
+\end{align*}\index{Vector operations!laws of}
 and
 \begin{align*}
 	(\alpha\beta)\vec v&=\alpha(\beta \vec v)\tag{Associativity II}\\
@@ -423,7 +423,7 @@ there is one standard one: the $xy$-coordinate system depicted below (which you'
 	\end{tikzpicture}
 \end{center}
 
-In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}\index[definitions]{Standard basis}\index{Standard basis}\index[definitions]{Basis!standard basis}\index{Basis!standard basis}.
+In conjunction with the standard coordinate system, there are also \emph{standard basis vectors}\index{Standard basis}\index{Basis!standard basis}.
 The vector $\xhat$ always points one unit in the direction of the positive $x$-axis and $\yhat$
 always points one unit in the direction of the positive $y$-axis.
 

--- a/problemsets-mat223/modules/module1.tex
+++ b/problemsets-mat223/modules/module1.tex
@@ -72,7 +72,7 @@ Having a definition of equality to lean on will help us when we need to prove th
 
 \Heading{Set-builder Notation}
 Specifying sets by listing all their elements can be a hassle, and if there are an infinite
-number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{Set-builder notation}\index{Set-builder notation}
+number of elements, it's impossible!  Fortunately, \emph{set-builder notation}\index{Set-builder notation}\index[definitions]{Set-builder notation}
 solves these problems.
 If $X$ is a set, we can define a subset 
 \[
@@ -82,7 +82,7 @@ which is read ``$Y$ is the set of $a$ in $X$ \emph{such that} some rule
 involving $a$ is true.''  If $X$ is intuitive, we may omit it and
 simply write $Y=\Set{a\given\text{some rule involving }a}$\footnote{ If you want
 to get technical, to make this notation unambiguous, you define a 
-\emph{universe of discourse}\index{Universe of discourse}.  That is, a set $\mathcal U$ containing
+\emph{universe of discourse}.  That is, a set $\mathcal U$ containing
 every object you might want to talk about.  Then $\Set{a\given\text{some rule involving }a}$
 is short for $\Set{a\in\mathcal U\given\text{some rule involving }a}$}.  You may equivalently
 use ``$|$'' instead of ``$:$'', writing $Y=\{a\,|\,\text{some rule involving }a\}$.
@@ -280,7 +280,7 @@ for any scalar $\alpha$ and any vectors
 $\vec v$ and $\vec w$, we could
 do algebra with vectors.
 
-We will define scalar multiplication\index[definitions]{Vector operations!scalar multiplication}\index{Vector operations!scalar multiplication}\index{Vector operations!addition}\index{Vector operations!addition} intuitively:
+We will define scalar multiplication\index[definitions]{Vector operations!scalar multiplication}\index{Vector operations!scalar multiplication}\index{Vector operations!addition}\index[definitions]{Vector operations!addition} intuitively:
 For a vector $\vec v$ and a scalar $\alpha>0$, the
 vector $\vec w=\alpha\vec v$ is the vector pointing in the same direction as
 $\vec v$ but with length scaled by $\alpha$.  That is, $\norm{\vec w}=\alpha\norm{\vec v}$.

--- a/problemsets-mat223/modules/module2.tex
+++ b/problemsets-mat223/modules/module2.tex
@@ -186,8 +186,8 @@ We can also use coordinates when writing a line in vector form. For example,
 \]
 corresponds to the line passing through $\mat{p_1\\p_2}$ with $\mat{d_1\\d_2}$ as a direction vector.
 
-The ``$t$'' that appears in a vector form is called the \emph{parameter variable}, and for this
-reason, some textbooks use the term \emph{parametric form} in place of ``vector form''. 
+The ``$t$'' that appears in a vector form is called the \emph{parameter variable}\index[definitions]{line!parameter variable}\index{line!parameter variable}, and for this
+reason, some textbooks use the term \emph{parametric form}\index{line!parametric form}\index[definitions]{line!parametric form} in place of ``vector form''. 
 
 \medskip
 Writing a line in vector form requires only a point on the line and a direction for the line\footnote{ Notice that
@@ -275,7 +275,7 @@ all represent the same line.  In the second equation, the direction vector is pa
 the third equation, a different point on the line was chosen.
 
 Recall that in vector form, the variable $t$ is called the \emph{parameter variable}.  It is an instance of
-a \emph{dummy variable}. In other words, $t$ is a placeholder---just because ``$t$'' appears in two different vector
+a \emph{dummy variable}\index{dummy variable}. In other words, $t$ is a placeholder---just because ``$t$'' appears in two different vector
 forms, doesn't mean it's the same quantity.
 
 To drive this point home, let's think about vector form in terms
@@ -355,7 +355,7 @@ Consider the lines described by
 \vec x &= t( -2, -6, 4) + ( 3, 1, 0 ).
 \end{align*}
 They have parallel directions since $( -2, -6, 4 ) = -2( 1, 3,-2 )$.
-Hence, in this case, we say the lines are \emph{parallel}\index{parallel lines}.  (How can
+Hence, in this case, we say the lines are \emph{parallel}\index{parallel lines}\index{line!parallel lines}.  (How can
 we be sure the lines are not the same?)
 \end{example}
 
@@ -368,7 +368,7 @@ Consider the lines described by
 They are not parallel because neither of the direction
 vectors is a multiple
 of the other.  They may or may not intersect.  (If they don't,
-	we say the lines are \emph{skew}\index{skew lines}.)  How can we find out?
+	we say the lines are \emph{skew}\index{skew lines}\index{line!skew lines}.)  How can we find out?
 	Mirroring our earlier approach,
 	we can set their equations equal and see if we can solve for a point
 	of intersection \emph{after ensuring we give their parametric variables
@@ -389,7 +389,7 @@ Reading coordinate by coordinate, we get three equations
     -2t + 1 &=  3s + 9
 \end{align*}
 in two unknowns  $s$ and $t$.  This is an {\it overdetermined\/}
-system, and it may or may not have a solution.
+system\index{overdetermined system}\index{system of linear equations!overdetermined system}, and it may or may not have a solution.
 The first two equations yield $t = -1$  and $s = -2$.  Putting
 these values in the last equation yields $(-2)(-1) + 1 = 3(-2) + 9$,
 which is indeed true.

--- a/problemsets-mat223/modules/module2.tex
+++ b/problemsets-mat223/modules/module2.tex
@@ -186,8 +186,8 @@ We can also use coordinates when writing a line in vector form. For example,
 \]
 corresponds to the line passing through $\mat{p_1\\p_2}$ with $\mat{d_1\\d_2}$ as a direction vector.
 
-The ``$t$'' that appears in a vector form is called the \emph{parameter variable}\index[definitions]{line!parameter variable}\index{line!parameter variable}, and for this
-reason, some textbooks use the term \emph{parametric form}\index{line!parametric form}\index[definitions]{line!parametric form} in place of ``vector form''. 
+The ``$t$'' that appears in a vector form is called the \emph{parameter variable}\index[definitions]{Parameter variable}\index{Parameter variable}, and for this
+reason, some textbooks use the term \emph{parametric form} in place of ``vector form''. 
 
 \medskip
 Writing a line in vector form requires only a point on the line and a direction for the line\footnote{ Notice that
@@ -275,7 +275,7 @@ all represent the same line.  In the second equation, the direction vector is pa
 the third equation, a different point on the line was chosen.
 
 Recall that in vector form, the variable $t$ is called the \emph{parameter variable}.  It is an instance of
-a \emph{dummy variable}\index{dummy variable}. In other words, $t$ is a placeholder---just because ``$t$'' appears in two different vector
+a \emph{dummy variable}. In other words, $t$ is a placeholder---just because ``$t$'' appears in two different vector
 forms, doesn't mean it's the same quantity.
 
 To drive this point home, let's think about vector form in terms
@@ -355,7 +355,7 @@ Consider the lines described by
 \vec x &= t( -2, -6, 4) + ( 3, 1, 0 ).
 \end{align*}
 They have parallel directions since $( -2, -6, 4 ) = -2( 1, 3,-2 )$.
-Hence, in this case, we say the lines are \emph{parallel}\index{parallel lines}\index{line!parallel lines}.  (How can
+Hence, in this case, we say the lines are \emph{parallel}\index{Line!parallel}.  (How can
 we be sure the lines are not the same?)
 \end{example}
 
@@ -368,7 +368,7 @@ Consider the lines described by
 They are not parallel because neither of the direction
 vectors is a multiple
 of the other.  They may or may not intersect.  (If they don't,
-	we say the lines are \emph{skew}\index{skew lines}\index{line!skew lines}.)  How can we find out?
+	we say the lines are \emph{skew}\index{Line!skew}.)  How can we find out?
 	Mirroring our earlier approach,
 	we can set their equations equal and see if we can solve for a point
 	of intersection \emph{after ensuring we give their parametric variables
@@ -389,7 +389,7 @@ Reading coordinate by coordinate, we get three equations
     -2t + 1 &=  3s + 9
 \end{align*}
 in two unknowns  $s$ and $t$.  This is an {\it overdetermined\/}
-system\index{overdetermined system}\index{system of linear equations!overdetermined system}, and it may or may not have a solution.
+system\index{System of linear equations!overdetermined system}, and it may or may not have a solution.
 The first two equations yield $t = -1$  and $s = -2$.  Putting
 these values in the last equation yields $(-2)(-1) + 1 = 3(-2) + 9$,
 which is indeed true.

--- a/problemsets-mat223/modules/module4.tex
+++ b/problemsets-mat223/modules/module4.tex
@@ -1,7 +1,7 @@
 Let $\vec a$ and $\vec b$ be vectors rooted at the same point and let
 $\theta$ denote the \emph{smaller} of the
 two angles between them (so $0\leq \theta \leq \pi$).
-The \emph{dot product}\index{dot product} of $\vec a$ and $\vec b$ is defined to be
+The \emph{dot product}\index{Dot product} of $\vec a$ and $\vec b$ is defined to be
 \[
 	\vec a\cdot \vec b=\norm{\vec a}\norm{\vec b}\cos \theta.
 \]
@@ -117,7 +117,7 @@ a right angle and the idea of one of them being $\vec 0$.
 
 \medskip
 Before we continue, let's pin down exactly what we mean by
-the \emph{direction}\index{direction}\index{positive direction} of a vector.
+the \emph{direction}\index{Direction}\index{Vector!positive direction of} of a vector.
 There are many ways we could define
 this term, but we'll go with the following.
 
@@ -272,7 +272,7 @@ When a line is expressed as above, we say it is expressed in \emph{normal form}.
 \bigskip
 What about in $\R^3$?
 Fix a non-zero vector $\vec n\in\R^3$ and let $\mathcal Q\subseteq\R^3$ be the set of vectors orthogonal to $\vec n$.
-$\mathcal Q$ is a plane through the origin, and again, we call $\vec n$ a \emph{normal vector}\index{normal vector} of the plane $\mathcal Q$.
+$\mathcal Q$ is a plane through the origin, and again, we call $\vec n$ a \emph{normal vector}\index{Normal vector} of the plane $\mathcal Q$.
 
 
 \begin{center}
@@ -371,7 +371,7 @@ and so $\mathcal P$ is the set of solutions to
 		n_xx+n_yy+n_zz=\alpha.
 \end{equation}
 Equation \eqref{EQScalarForm} is sometimes
-called \emph{scalar form}\index{scalar form of a plane}
+called \emph{scalar form}\index{Plane!scalar form of}
 of a plane.  For us, it will not be important to distinguish between scalar and normal form, but
 what is important is that we can use the row reduction algorithm to write the complete solution
 to \eqref{EQScalarForm}, and this complete solution will necessarily be written in vector form.

--- a/problemsets-mat223/modules/module6.tex
+++ b/problemsets-mat223/modules/module6.tex
@@ -38,7 +38,7 @@ of linear combinations is still a linear combination, a span
 is \emph{closed} with respect to linear combinations. That is, 
 by taking linear combinations of vectors in a span, you cannot
 escape the span. In general, sets that have this property are called
-\emph{subspaces}\index{subspace}.
+\emph{subspaces}\index{Subspace}.
 
 \SavedDefinitionRender{Subspace}
 

--- a/problemsets-mat223/modules/module7.tex
+++ b/problemsets-mat223/modules/module7.tex
@@ -20,7 +20,7 @@ We can rewrite \eqref{EQREGSYS} using matrix-vector multiplication:
 \[
 	\underbrace{\mat{1&2&-2\\2&1&-5\\1&-4&1}}_{A}\mat{x\\y\\z}=\mat{-15\\-21\\18}.
 \]
-The matrix $A$ on the left is called the \emph{coefficient matrix}\index{coefficient matrix} because it
+The matrix $A$ on the left is called the \emph{coefficient matrix}\index{Coefficient matrix} because it
 is made up of the coefficients from equation \eqref{EQREGSYS}.
 
 \medskip


### PR DESCRIPTION
Add index for Module 1 and 2.

I used the following index guideline which is inspired by the index of _Galois Theory_ by Joseph Rotman (applied to both generic index and index of definitions):
A term like "linear combination" will appear as an entry in the index.
A term like "convex linear combination" will appear twice in the index: once as an entry "convex linear combination" and once as a subentry "convex" of the entry "linear combination". 