### PR TITLE
Add index reg. Module 3,4,5,6,7

### DIFF
--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -72,8 +72,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ZeroVector, title={Zero Vector}]
-		The \emph{zero vector}\index{Zero vector ($\vec 0$)}\index[definitions]{Zero vector ($\vec 0$)}, notated as
-		$\vec 0$\index[symbols]{$\vec 0$},
+		The \emph{zero vector}\index{Zero vector ($\vec 0$)}\index[definitions]{Zero vector ($\vec 0$)}, notated as $\vec 0$[\index[symbols]{$\vec 0$},
 		is the vector with no magnitude.
 \end{SaveDefinition}
 
@@ -175,12 +174,10 @@
 	title={Trivial Linear Combination}]
 
 	The linear combination $\alpha_1\vec v_1+\cdots+\alpha_n\vec v_n$ is called
-	\emph{trivial}\index{Linear combination!trivial}
+	\emph{trivial}\index{Linear combination!trivial}\index[definitions]{Linear combination!trivial}
 	if $\alpha_1=\cdots=\alpha_n=0$. If at least one $\alpha_i\neq 0$,
 	the linear combination is called \emph{non-trivial}.
 \end{SaveDefinition}
-
-% 2020/6/9 Above; editing finished; review
 
 \begin{SaveDefinition}[
 	key=LinearlyDependentIndependentAlgebraic,
@@ -198,7 +195,7 @@
 
 	A system of linear equations or a vector equation in the variables $\alpha_1$, \ldots, 
 	$\alpha_n$ is called
-	\emph{homogeneous} if it takes the form
+	\emph{homogeneous}\index{System of linear equations!homogeneous}\index[definitions]{Homogeneous system} if it takes the form
 	\[
 		\alpha_1\vec v_1+\alpha_2\vec v_2+\cdots +\alpha_n\vec v_n=\vec 0,
 	\]
@@ -233,7 +230,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Direction, title={Direction}]
-	The vector $\vec u$ points in the \emph{direction} of
+	The vector $\vec u$ points in the \emph{direction}\index{Direction}\index{Vector!positive direction of} of
 	the vector $\vec v$ if $k\vec u=\vec v$ for some scalar $k$.
 	The vector $\vec u$ points in the \emph{positive direction} of
 	$\vec v$ if $k\vec u=\vec v$ for some positive scalar $k$.
@@ -252,19 +249,19 @@
 
 \begin{SaveDefinition}[key=Orthogonal, title={Orthogonal}]
 	Two vectors $\vec u$ and $\vec v$ are
-	\emph{orthogonal} to each other if $\vec u\cdot \vec v=0$. The word orthogonal
+	\emph{orthogonal}\index{Orthogonality}\index[definitions]{Orthogonality} to each other if $\vec u\cdot \vec v=0$. The word orthogonal
 	is synonymous with the word perpendicular.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=NormalVector, title={Normal Vector}]
 	A
-	\emph{normal vector} to a line (or plane or hyperplane) is a non-zero
+	\emph{normal vector}\index[definitions]{Line!normal vector}[definitions]\index{Plane!normal vector}\index{Line!normal vector}\index{Plane!normal vector} to a line (or plane or hyperplane) is a non-zero
 	vector that is orthogonal to all direction vectors for the line (or plane
 	or hyperplane).
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=NormalFormofaLine, title={Normal Form of a Line}]
-	A line $\ell\subseteq \R^2$ is expressed in \emph{normal form} if $\ell$
+	A line $\ell\subseteq \R^2$ is expressed in \emph{normal form}\index{Line!normal form}\index[definitions]{Line!normal form} if $\ell$
 	is the solution set to the equation
 	\[
 		\vec n\cdot (\vec x-\vec p)=0
@@ -273,7 +270,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Hyperplane, title={Hyperplane}]
-	The set $X\subseteq \R^n$ is called a \emph{hyperplane} if there
+	The set $X\subseteq \R^n$ is called a \emph{hyperplane}\index{Hyperplane}\index[definitions]{Hyperplane} if there
 	exists $\vec n\neq \vec 0$ and $\vec p$ so that $X$ is the set of solutions
 	to the equation
 	\[
@@ -285,14 +282,14 @@
 \begin{SaveDefinition}[key=Projection, title={Projection}]
 	Let $X$ be a set. The
 	\emph{projection} of the vector $\vec v$ onto $X$, written $\Proj_{X}\vec
-	v$, is the closest point in $X$ to $\vec v$.
+	v$, is the closest point in $X$ to $\vec v$.\index[definitions]{Projection}\index{Projection}\index[symbols]{$\Proj_{X}\vec v$}
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Component, title={Vector Components}]
 	Let $\vec u$ and $\vec v\neq \vec 0$ be vectors. The
 	\emph{vector component of $\vec u$ in the $\vec v$ direction}, written $\Comp_{\vec
 	v}\vec u$, is the vector in the direction of $\vec v$ so that
-	$\vec u-\Comp_{\vec v}\vec u$ is orthogonal to $\vec v$.
+	$\vec u-\Comp_{\vec v}\vec u$ is orthogonal to $\vec v$.\index{Vector component}\index[definitions]{Vector component}\index[symbols]{$\Comp_{\vec v}\vec u$}
 	\begin{center}
 		\usetikzlibrary{patterns, decorations.pathreplacing}
 		\begin{tikzpicture}[>=latex, scale=2.5]
@@ -318,7 +315,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Subspace, title={Subspace}]
-	A non-empty subset $V\subseteq \R^{n}$ is called a \emph{subspace} if for all $\vec u,\vec v\in V$ and all
+	A non-empty subset $V\subseteq \R^{n}$ is called a \emph{subspace}\index{Subspace}\index[definitions]{Subspaces} if for all $\vec u,\vec v\in V$ and all
 	scalars $k$ we have
 	\begin{enumerate}
 		\item[(i)] $\vec u+\vec v\in V$; and
@@ -328,23 +325,23 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=TrivialSubspace, title={Trivial Subspace}]
-	The subset $\Set{\vec 0}\subseteq\R^n$ is called the \emph{trivial subspace}.
+	The subset $\Set{\vec 0}\subseteq\R^n$ is called the \emph{trivial subspace}\index{Subspace!trivial subspace}\index[definitions]{Subspace!trivial subspace}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Basis, title={Basis}]
 	A
-	\emph{basis} for a subspace $\mathcal V$ is a linearly independent set of vectors,
+	\emph{basis}\index[definitions]{Basis}\index{Basis} for a subspace $\mathcal V$ is a linearly independent set of vectors,
 	$\mathcal B$, so that $\Span\mathcal B=\mathcal V$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Dimension, title={Dimension}]
 	The
-	\emph{dimension} of a subspace $V$ is the number of elements in a basis
+	\emph{dimension}\index[definitions]{Subspace!dimension}\index{Subspace!dimension} of a subspace $V$ is the number of elements in a basis
 	for $V$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=StandardBasisforRn, title={Standard Basis}]
-	The \emph{standard basis} for $\R^n$ is the set $\Set{\vec e_1,\ldots,\vec e_n}$ where
+	The \emph{standard basis}\index[definitions]{Basis!standard basis}\index{Basis!standard basis} for $\R^n$ is the set $\Set{\vec e_1,\ldots,\vec e_n}$ where
 	\[
 		\vec e_1=\matc{1\\0\\0\\\vdots}\qquad
 		\vec e_2=\matc{0\\1\\0\\\vdots}\qquad

--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -72,7 +72,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ZeroVector, title={Zero Vector}]
-		The \emph{zero vector}\index{Zero vector ($\vec 0$)}\index[definitions]{Zero vector ($\vec 0$)}, notated as $\vec 0$[\index[symbols]{$\vec 0$},
+		The \emph{zero vector}\index{Zero vector ($\vec 0$)}\index[definitions]{Zero vector ($\vec 0$)}, notated as $\vec 0$\index[symbols]{$\vec 0$},
 		is the vector with no magnitude.
 \end{SaveDefinition}
 
@@ -249,7 +249,7 @@
 
 \begin{SaveDefinition}[key=Orthogonal, title={Orthogonal}]
 	Two vectors $\vec u$ and $\vec v$ are
-	\emph{orthogonal}\index{Orthogonality}\index[definitions]{Orthogonality} to each other if $\vec u\cdot \vec v=0$. The word orthogonal
+	\emph{orthogonal}\index{Orthogonal}\index[definitions]{Orthogonal} to each other if $\vec u\cdot \vec v=0$. The word orthogonal
 	is synonymous with the word perpendicular.
 \end{SaveDefinition}
 
@@ -290,7 +290,7 @@
 	Let $\vec u$ and $\vec v\neq \vec 0$ be vectors. The
 	\emph{vector component of $\vec u$ in the $\vec v$ direction}, written $\Comp_{\vec
 	v}\vec u$, is the vector in the direction of $\vec v$ so that
-	$\vec u-\Comp_{\vec v}\vec u$ is orthogonal to $\vec v$.\index{Vector component}\index[definitions]{Vector component}\index[symbols]{$\Comp_{\vec v}\vec u$}
+	$\vec u-\Comp_{\vec v}\vec u$ is orthogonal to $\vec v$.\index{Vector component}\index[definitions]{Vector component}\index[symbols]{$\Vcomp_{\vec v}\vec u$}
 	\begin{center}
 		\usetikzlibrary{patterns, decorations.pathreplacing}
 		\begin{tikzpicture}[>=latex, scale=2.5]
@@ -358,8 +358,8 @@
 
 	Let $\mathcal B=\Set{\vec b_1,\ldots,\vec b_n}$ be a basis for a
 	subspace $V$ and let $\vec v\in V$. The
-	\emph{representation of $\vec v$ in the $\mathcal B$ basis}, notated $[\vec
-	v]_{\mathcal B}$, is the column matrix
+	\emph{representation of $\vec v$ in the $\mathcal B$ basis}\index{Vector!representation in a basis}\index[definitions]{Vector!representation in a basis}, notated $[\vec
+	v]_{\mathcal B}$\index[symbols]{$[\vec v]_{\mathcal B}$}, is the column matrix
 	\[
 		[\vec v]_{\mathcal B}= \matc{\alpha_1\\\vdots\\\alpha_n}
 	\]
@@ -377,7 +377,7 @@
 
 \begin{SaveDefinition}[key=OrthonormalBasis, title={Orthonormal Basis}]
 	A basis $\mathcal B=\{\vec b_{1},\ldots,\vec b_{n}\}$ is called
-	\emph{orthonormal} if every basis vector is a unit vector and all
+	\emph{orthonormal}\index[definitions]{Basis!orthonormal basis}\index{Basis!orthonormal basis} if every basis vector is a unit vector and all
 	basis vectors are orthogonal to each other. That is,
 	\[
 		\vec b_i\cdot \vec b_j=\begin{cases}
@@ -389,18 +389,18 @@
 
 \begin{SaveDefinition}[key=OrientationofaBasis, title={Orientation of a Basis}]
 	The ordered basis $\mathcal B=\{\vec b_{1},\ldots,\vec b_{n}\}$ is
-	\emph{right-handed} or
-	\emph{positively oriented} if it can be continuously transformed to the
+	\emph{right-handed}\index[definitions]{Basis!right-handed}\index{Basis!right handed} or
+	\emph{positively oriented}\index[definitions]{Basis!positively oridented}\index{Basis!positively oriented} if it can be continuously transformed to the
 	standard basis (with $\vec b_{i}\mapsto \vec e_{i}$) while remaining
 	linearly independent throughout the transformation. Otherwise,
 	$\mathcal B$ is called
-	\emph{left-handed} or
-	\emph{negatively oriented}.
+	\emph{left-handed}\index[definitions]{Basis!left-handed}\index{Basis!left-handed} or
+	\emph{negatively oriented}\index[definitions]{Basis!negatively oriented}\index{negatively oriented}.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=LinearTransformation, title={Linear Transformation}]
 	Let $V$ and $W$ be subspaces. A function $T:V\to W$ is called a
-	\emph{linear transformation} if
+	\emph{linear transformation}\index[definitions]{Linear transformation}\index{Linear transformation} if
 	\[
 		T(\vec u+\vec v)=T(\vec u)+T(\vec v) \qquad\text{and}\qquad T(\alpha
 		\vec v)=\alpha T(\vec v)
@@ -410,7 +410,7 @@
 
 \begin{SaveDefinition}[key=ImageofaSet, title={Image of a Set}]
 	Let $L:\R^n\to \R^m$ be a transformation and let $X\subseteq \R^n$ be a set. The
-	\emph{image of the set $X$ under $L$}, denoted $L(X)$, is the set
+	\emph{image of the set $X$ under $L$}\index[definitions]{Set!image of}\index{Set!image of}, denoted $L(X)$\index[symbols]{$L(X)$ (Image of a set)}, is the set
 	\[
 		L(X)=\Set{\vec y\in \R^m \given \vec y=L(\vec x)\text{ for some }\vec
 		x\in X}.
@@ -418,7 +418,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=CompositionofFunctions, title={Composition of Functions}]
-	Let $f:A\to B$ and $g:B\to C$. The \emph{composition} of $g$ and $f$, notated $g\circ f$,
+	Let $f:A\to B$ and $g:B\to C$. The \emph{composition}\index[definitions]{Function!composition}\index{Function!composition} of $g$ and $f$, notated $g\circ f$\index[symbols]{$g\circ f$},
 	is the function $h:A\to C$ defined by
 	\[
 		h(x)=g\circ f(x) = g\Big(f(x)\Big).
@@ -428,7 +428,7 @@
 \begin{SaveDefinition}[key=Range, title={Range}]
 	The
 	\emph{range} (or
-	\emph{image}) of a linear transformation $T:V\to W$ is the set of vectors
+	\emph{image})\index[definitions]{Linear transformation!range (image)}\index{Linear transformation!range (image)} of a linear transformation $T:V\to W$ is the set of vectors
 	that $T$ can output. That is,
 	\[
 		\Range(T)=\Set{\vec y\in W \given \vec y=T\vec x\text{ for some }\vec
@@ -440,7 +440,7 @@
 \begin{SaveDefinition}[key=NullSpace, title={Null Space}]
 	The
 	\emph{null space} (or
-	\emph{kernel}) of a linear transformation $T:V\to W$ is the set of vectors
+	\emph{kernel})\index[definitions]{Linear transformation!null space (kernel)}\index{Linear transformations!null space (kernel)} of a linear transformation $T:V\to W$ is the set of vectors
 	that get mapped to the zero vector under $T$. That is,
 	\[
 		\Null(T)=\Set{\vec x\in V \given T\vec x=\vec 0}.
@@ -453,7 +453,7 @@
 	title={Induced Transformation}]
 
 	Let $M$ be an $n\times m$ matrix. We say $M$
-	\emph{induces} a linear transformation $\mathcal T_{M}:\R^{m}\to\R^{n}$ defined
+	\emph{induces}\index[definitions]{Matrix!linear transformation induced by}\index{Matrix!linear transformation induced by}\index[definitions]{Linear transformation!induced}\index{Linear transformation!induced} a linear transformation $\mathcal T_{M}:\R^{m}\to\R^{n}$ defined
 	by
 	\[
 		[\mathcal T_{M}\vec v]_{\mathcal E'}= M[\vec v]_{\mathcal E},
@@ -474,7 +474,7 @@
 		\vdots &\vdots&\vdots &\ddots&\vdots\\
 		a_{n1}&a_{n2}&a_{n3}&\cdots&a_{nm}}.
 	\]
-	The \emph{transpose} of $M$, notated $M^T$, is the $m\times n$ matrix produced by swapping the rows
+	The \emph{transpose}\index[definitions]{Matrix!transpose of}\index{Matrix!transpose of} of $M$, notated $M^T$\index[symbols]{$M^T$}, is the $m\times n$ matrix produced by swapping the rows
 	and columns of $M$. That is
 	\[
 		M^T=\matc{
@@ -490,14 +490,14 @@
 	key=ElementaryMatrix,
 	title={Elementary Matrix}]
 
-	A matrix is called an \emph{elementary matrix} if it is an identity matrix with a single elementary row operation applied.
+	A matrix is called an \emph{elementary matrix}\index[definitions]{Matrix!elementary matrix}\index{Matrix!elementary matrix} if it is an identity matrix with a single elementary row operation applied.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
 	key=MatrixInverse,
 	title={Matrix Inverse}]
 		
-	The \emph{inverse} of a matrix $A$ is a
+	The \emph{inverse}\index[definitions]{Matrix!inverse of}\index{Matrix!inverse of} of a matrix $A$ is a
 		matrix $B$ such that $AB=I$ and $BA=I$.
 		In this case, $B$ is called the inverse of $A$ and is notated $A^{-1}$.
 \end{SaveDefinition}
@@ -506,8 +506,8 @@
 	key=IdentityFunction,
 	title={Identity Function}]
 	
-	Let $X$ be a set. The \emph{identity function} with domain and codomain $X$,
-	notated $\Ident:X\to X$, is the function satisfying
+	Let $X$ be a set. The \emph{identity function}\index[definitions]{Function!identity}\index{Function!identity} with domain and codomain $X$,
+	notated $\Ident:X\to X$\index[symbols]{$\Ident$}, is the function satisfying
 	\[
 		\Ident(x)=x
 	\]
@@ -518,9 +518,9 @@
 	key=InverseFunction,
 	title={Inverse Function}]
 		
-	Let $f:X\to Y$ be a function. We say $f$ is \emph{invertible} if
+	Let $f:X\to Y$ be a function. We say $f$ is \emph{invertible}\index[definitions]{Function!invertible function}\index{Function!invertible function} if
 	there exists a function $g:Y\to X$ so that $f\circ g=\Ident$ and $g\circ f=\Ident$.
-	In this case, we call $g$ an \emph{inverse} of $f$ and write
+	In this case, we call $g$ an \emph{inverse}\index[definitions]{Function!inverse of}\index{Function!inverse of} of $f$ and write
 	\[
 		f^{-1}=g.
 	\]
@@ -530,7 +530,7 @@
 	key=Onetoone,
 	title={One-to-one}]
 		
-	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one} (or \emph{injective}) if
+	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one}\index[definitions]{One-to-one function}\index{One-to-one function} (or \emph{injective}) if
 	distinct inputs to $f$ produce distinct outputs. That is $f(x)=f(y)$ implies $x=y$.
 \end{SaveDefinition}
 
@@ -539,7 +539,7 @@
 	title={Onto}]
 		
 	Let $f:X\to Y$ be a function.
-	We say $f$ is \emph{onto} (or \emph{surjective}) if every point in the codomain of $f$ gets mapped to.
+	We say $f$ is \emph{onto}\index{Onto function}\index[definitions]{Onto function} (or \emph{surjective}) if every point in the codomain of $f$ gets mapped to.
 	That is $\Range(f)=Y$.
 \end{SaveDefinition}
 
@@ -547,63 +547,64 @@
 	key=IdentityMatrix,
 	title={Identity Matrix}]
 	
-	An \emph{identity matrix} is a square matrix with ones on the diagonal
+	An \emph{identity matrix}\index{Matrix!identity}\index[definitions]{Matrix!identity} is a square matrix with ones on the diagonal
 	and zeros everywhere else. The $n\times n$ identity matrix is denoted $I_{n\times n}$,
 	or just $I$ when its size is implied.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=FundamentalSubspaces, title={Fundamental Subspaces}]
+	\index{Matrix!fundmamental subspaces of}\index[definitions]{Matrix!fundamental subspaces of}
 	Associated with any matrix $M$ are three fundamental subspaces: the
-	\emph{row space} of $M$, denoted $\Row(M)$, is the span of the rows of
+	\emph{row space}\index{Matrix!row space}\index[definitions]{Matrix!row space} of $M$, denoted $\Row(M)$\index[symbols]{$\Row(M)$}, is the span of the rows of
 	$M$; the
-	\emph{column space} of $M$, denoted $\Col(M)$, is the span of the
+	\emph{column space}\index{Matrix!column space}\index[definitions]{Matrix!column space} of $M$, denoted $\Col(M)$\index[symbols]{$\Col(M)$}, is the span of the
 	columns of $M$; and the
-	\emph{null space} of $M$, denoted $\Null(M)$, is the set of solutions to
+	\emph{null space}\index{Matrix!null space}\index[definitions]{Matrix!null space} of $M$, denoted $\Null(M)$\index[symbols]{$\Null(M)$}, is the set of solutions to
 	$M\vec x=\vec 0$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=RankofaLinearTransformation, title={Rank of a Linear Transformation}]
 	For a linear transformation $T:\R^n\to \R^m$, the
-	\emph{rank} of $T$, denoted $\Rank(T)$, is the dimension of the range of
+	\emph{rank}\index[definitions]{Linear transformation!rank}\index{Linear transformation!rank} of $T$, denoted $\Rank(T)$\index[symbols]{$\Rank(T)$}, is the dimension of the range of
 	$T$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=RankofaMatrix, title={Rank of a Matrix}]
 	Let $M$ be a matrix.
-	The \emph{rank} of $M$, denoted $\Rank(M)$, is the rank of
+	The \emph{rank}\index[definitions]{Matrix!rank}\index{Matrix!rank} of $M$, denoted $\Rank(M)$\index[symbols]{$\Rank(M)$}, is the rank of
 	the linear transformation induced by $M$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=NullityofaMatrix, title={Nullity of a Matrix}]
 	Let $M$ be a matrix.
-	The \emph{nullity} of $M$, denoted $\Nullity(M)$, is the nullity of
+	The \emph{nullity}\index[definitions]{Matrix!nullity}\index{Matrix!nullity} of $M$, denoted $\Nullity(M)$\index[symbols]{$\Nullity(M)$}, is the nullity of
 	the linear transformation induced by $M$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Rank, title={Rank}]
 	For a linear transformation $T:\R^n\to \R^m$, the
 	\emph{rank} of $T$, denoted $\Rank(T)$, is the dimension of the range of
-	$T$.
+	$T$.\index[definitions]{Linear transformation!rank}\index{Linear transformation!rank}
 
 	For an $m\times n$ matrix $M$, the
 	\emph{rank} of $M$, denoted $\Rank(M)$, is the number of pivots in
-	$\rref(M)$.
+	$\rref(M)$.\index[definitions]{Matrix!nullity}\index{Matrix!nullity}
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Nullity, title={Nullity}]
 	For a linear transformation $T:\R^n\to \R^m$, the
 	\emph{nullity} of $T$, denoted $\Nullity(T)$, is the dimension of the null space of
-	$T$.
+	$T$.\index[definitions]{Linear transformation!nullity}\index{Linear transformation!nullity}
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ChangeofBasisMatrix, title={Change of Basis Matrix}]
 	Let $\mathcal A$ and $\mathcal B$ be bases for $\R^n$. The matrix $M$ is called
-	a \emph{change of basis} matrix (which converts from $\mathcal A$ to $\mathcal B$) if
+	a \emph{change of basis} matrix\index[definition]{Change of basis matrix}\index{Change of basis matrix} (which converts from $\mathcal A$ to $\mathcal B$) if
 	for all $\vec x\in \R^n$
 	\[
 		M[\vec x]_{\mathcal A}=[\vec x]_{\mathcal B}.
 	\]
-	 Notationally, $\BasisChange{\mathcal A}{\mathcal B}$
+	 Notationally, $\BasisChange{\mathcal A}{\mathcal B}$\index[symbols]{$\BasisChange{\mathcal A}{\mathcal B}$}
 	stands for the change of basis matrix converting from $\mathcal A$ to $\mathcal B$,
 	and we may write $M=\BasisChange{\mathcal A}{\mathcal B}$.
 \end{SaveDefinition}
@@ -618,6 +619,7 @@
 	\]
 	In this case, we say the matrix $[\mathcal T]_{\mathcal B}$ is the representation
 	of $\mathcal T$ in the $\mathcal B$ basis.
+	\index{Matrix!of a linear transformation}\index[definitions]{Matrix!of a linear transformation}\index{Linear transformation!representation in a basis}\index[definitions]{Linear transformation!representation in a basis}
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=SimilarMatrices, title={Similar Matrices}]
@@ -627,48 +629,48 @@
 	$A\sim B$ if there is an invertible matrix $X$ so that
 	\[
 		A=XBX^{-1}.
-	\]
+	\]\index[definitions]{Matrix!similar}\index{Matrix!similar}
 
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Unitncube, title={Unit $n$-cube}]
 	The
-	\emph{unit $n$-cube} is the $n$-dimensional cube with sides given by the
+	\emph{unit $n$-cube}\index[definitions]{Unit $n$-cube ($C_n$)}\index{Unit $n$-cube ($C_n$)} is the $n$-dimensional cube with sides given by the
 	standard basis vectors and lower-left corner located at the origin. That
 	is
 	\[
 		C_{n}=\Set*{\vec x\in\R^n:\vec x=\sum_{i=1}^n\alpha_i\vec e_i\text{
 		for some }\alpha_1,\ldots,\alpha_n\in[0,1]}=[0,1]^{n}.
-	\]
+	\]\index[symbols]{$C_n$}
 
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Determinant, title={Determinant}]
 	The
-	\emph{determinant} of a linear transformation $X:\R^{n}\to \R^{n}$, denoted $\det(X)$ or $\Abs{X}$, is
+	\emph{determinant}\index{Determinant}\index[definitions]{Determinant} of a linear transformation $X:\R^{n}\to \R^{n}$, denoted $\det(X)$\index[symbols]{$\det(X)$} or $\Abs{X}$\index[symbols]{$\Abs{X}$}, is
 	the oriented volume of the image of the unit $n$-cube. The determinant of
 	a square matrix is the determinant of its induced transformation.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=OrientationPreservingLinearTransformation, title={Orientation Preserving Linear Transformation}]
 	Let $\mathcal T:\R^n\to\R^n$ be a linear transformation. We say $\mathcal T$
-	is \emph{orientation preserving} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
+	is \emph{orientation preserving}\index[definitions]{Linear transformation!orientation preserving}\index{Linear transformation!orientation preserving} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
 	is positively oriented  and we say $\mathcal T$
-	is \emph{orientation reversing} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
+	is \emph{orientation reversing}\index[definitions]{Linear transformation!orientation reversing}\index{Linear transformation!orientation reversing} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
 	is negatively oriented. If $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
 	is not a basis for $\R^n$, then $\mathcal T$ is neither orientation preserving nor orientation reversing.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Eigenvector, title={Eigenvector}]
 	Let $X$ be a linear transformation or a matrix. An
-	\emph{eigenvector} for $X$ is a non-zero vector that doesn't change
+	\emph{eigenvector}\index[definitions]{Eigenvector}\index{Eigenvector} for $X$ is a non-zero vector that doesn't change
 	directions when $X$ is applied. That is, $\vec v\neq \vec 0$ is an
 	eigenvector for $X$ if
 	\[
 		X\vec v=\lambda \vec v
 	\]
 	 for some scalar $\lambda$. We call $\lambda$ the
-	\emph{eigenvalue} of $X$ corresponding to the eigenvector $\vec v$.
+	\emph{eigenvalue}\index[definitions]{Eigenvalue}\index{Eigenvalue} of $X$ corresponding to the eigenvector $\vec v$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -676,29 +678,29 @@
 	title={Characteristic Polynomial}]
 
 	For a matrix $A$, the
-	\emph{characteristic polynomial} of $A$ is
+	\emph{characteristic polynomial}\index{Characteristic polynomial}\index[definition]{Characteristic Polynomial} of $A$ is
 	\[
 		\chr(A)=\det(A-\lambda I).
-	\]
+	\]\index[symbols]{$\chr(A)$}
 
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Diagonalizable, title={Diagonalizable}]
 	A matrix is
-	\emph{diagonalizable} if it is similar to a diagonal matrix.
+	\emph{diagonalizable}\index{Matrix!diagonalizable}\index[definitions]{Matrix!diagonalizible} if it is similar to a diagonal matrix.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Eigenspace, title={Eigenspace}]
 	Let $A$ be an $n\times n$ matrix with eigenvalues
 	$\lambda_{1},\ldots,\lambda_{m}$. The
-	\emph{eigenspace} of $A$ corresponding to the eigenvalue $\lambda_{i}$
+	\emph{eigenspace}\index[definitions]{Eigenspace}\index{Eigenspace} of $A$ corresponding to the eigenvalue $\lambda_{i}$
 	is the null space of $A-\lambda_{i} I$. That is, it is the space spanned
 	by all eigenvectors that have the eigenvalue $\lambda_{i}$.
 
 	The
-	\emph{geometric multiplicity} of an eigenvalue $\lambda_{i}$ is the
+	\emph{geometric multiplicity}\index[definitions]{Eigenvalue!geometric multiplicity}\index{Eigenvalue!geometric multiplicity} of an eigenvalue $\lambda_{i}$ is the
 	dimension of the corresponding eigenspace. The
-	\emph{algebraic multiplicity} of $\lambda_{i}$ is the number of times
+	\emph{algebraic multiplicity}\index[definitions]{Eigenvalue!algebraic multiplicity}\index{Eigenvalue!algebraic multiplicity} of $\lambda_{i}$ is the number of times
 	$\lambda_{i}$ occurs as a root of the characteristic polynomial of $A$ (i.e.,
 	the number of times $x-\lambda_{i}$ occurs as a factor).
 \end{SaveDefinition}

--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -262,7 +262,7 @@
 
 \begin{SaveDefinition}[key=NormalFormofaLine, title={Normal Form of a Line}]
 
-	A line $\ell\subseteq \R^2$ is expressed in \emph{normal form} if there exist
+	A line $\ell\subseteq \R^2$ is expressed in \emph{normal form}\index[definitions]{Line!normal form}\index{Line!normal form} if there exist
 	vectors $\vec n,\vec p$ so that $\ell$ is the solution set to the equation
 	\[
 		\vec n\cdot (\vec x-\vec p)=0.

--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -389,7 +389,7 @@
 
 \begin{SaveDefinition}[key=OrientationofaBasis, title={Orientation of a Basis}]
 	The ordered basis $\mathcal B=\{\vec b_{1},\ldots,\vec b_{n}\}$ is
-	\emph{right-handed}\index[definitions]{Basis!right-handed}\index{Basis!right handed} or
+	\emph{right-handed}\index[definitions]{Basis!right-handed}\index{Basis!right-handed} or
 	\emph{positively oriented}\index[definitions]{Basis!positively oridented}\index{Basis!positively oriented} if it can be continuously transformed to the
 	standard basis (with $\vec b_{i}\mapsto \vec e_{i}$) while remaining
 	linearly independent throughout the transformation. Otherwise,
@@ -506,7 +506,7 @@
 	key=IdentityFunction,
 	title={Identity Function}]
 	
-	Let $X$ be a set. The \emph{identity function}\index[definitions]{Function!identity}\index{Function!identity} with domain and codomain $X$,
+	Let $X$ be a set. The \emph{identity function}\index[definitions]{Function!identity function}\index{Function!identity function} with domain and codomain $X$,
 	notated $\Ident:X\to X$\index[symbols]{$\Ident$}, is the function satisfying
 	\[
 		\Ident(x)=x
@@ -530,7 +530,7 @@
 	key=Onetoone,
 	title={One-to-one}]
 		
-	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one}\index[definitions]{One-to-one function}\index{One-to-one function} (or \emph{injective}) if
+	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one}\index[definitions]{One-to-one function}\index{One-to-one function} (or \emph{injective}\index{Injective function}\index[definitions]{Injective function}) if
 	distinct inputs to $f$ produce distinct outputs. That is $f(x)=f(y)$ implies $x=y$.
 \end{SaveDefinition}
 
@@ -539,7 +539,7 @@
 	title={Onto}]
 		
 	Let $f:X\to Y$ be a function.
-	We say $f$ is \emph{onto}\index{Onto function}\index[definitions]{Onto function} (or \emph{surjective}) if every point in the codomain of $f$ gets mapped to.
+	We say $f$ is \emph{onto}\index{Onto function}\index[definitions]{Onto function} (or \emph{surjective}\index{Surjective function}\index[definitions]{Surjective function}) if every point in the codomain of $f$ gets mapped to.
 	That is $\Range(f)=Y$.
 \end{SaveDefinition}
 
@@ -547,7 +547,7 @@
 	key=IdentityMatrix,
 	title={Identity Matrix}]
 	
-	An \emph{identity matrix}\index{Matrix!identity}\index[definitions]{Matrix!identity} is a square matrix with ones on the diagonal
+	An \emph{identity matrix}\index{Matrix!identity matrix}\index[definitions]{Matrix!identity matrix} is a square matrix with ones on the diagonal
 	and zeros everywhere else. The $n\times n$ identity matrix is denoted $I_{n\times n}$,
 	or just $I$ when its size is implied.
 \end{SaveDefinition}

--- a/book/modules/module3.tex
+++ b/book/modules/module3.tex
@@ -187,7 +187,7 @@ if $X=\Span\Set{\vec v_1,\ldots,\vec v_n}$ is a span, we know $\vec 0=0\vec v_1+
 and so every span passes through the origin.
 
 
-As it turns out, spans exactly describe points, lines, planes, and volumes\footnote{
+As it turns out, spans exactly describe points, lines, planes, and volumes\index{Volume}\footnote{
  We use the word \emph{volume} to indicate the higher-dimensional analogue of a plane.} through the origin.
 
 \begin{example}
@@ -306,7 +306,7 @@ is as a set.}. Finally, $Z$ is the union of three translated copies of $C$.
 	\end{tikzpicture}
 \end{center}
 
-\Heading{Translated Spans}
+\Heading{Translated Spans}\index{Span!translated}
 
 Set addition allows us to easily create parallel lines and planes by translation. For example,
 consider the lines $\ell_1$ and $\ell_2$ given in vector form as $\vec x=t\vec d$ and $\vec x=t\vec d+\vec p$,

--- a/book/modules/module4.tex
+++ b/book/modules/module4.tex
@@ -5,7 +5,7 @@ The \emph{dot product}\index{Dot product} of $\vec a$ and $\vec b$ is defined to
 \[
 	\vec a\cdot \vec b=\norm{\vec a}\norm{\vec b}\cos \theta.
 \]
-We will call this the \emph{geometric definition of the dot product}.
+\index[symbols]{$\vec a\cdot \vec b$}We will call this the \emph{geometric definition of the dot product}\index{Dot product!geometric definition}\index[definitions]{Dot product!geometric definition}.
 
 \begin{center}
 	\newcommand{\tikzAngleOfLine}{\tikz@AngleOfLine}
@@ -44,7 +44,7 @@ We will call this the \emph{geometric definition of the dot product}.
 	\end{tikzpicture}
 \end{center}
 
-The dot product is also sometimes called the \emph{scalar product} because
+The dot product is also sometimes called the \emph{scalar product}\index{Scalar product} because
 the result is a scalar.
 
 Algebraically, we can define the dot product in terms of coordinates:
@@ -52,7 +52,7 @@ Algebraically, we can define the dot product in terms of coordinates:
 	\matc{a_1\\a_2\\\vdots\\a_n}\cdot \matc{b_1\\b_2\\\vdots\\b_n}
 	=a_1b_1+a_2b_2+\cdots+a_nb_n.
 \]
-We will call this the \emph{algebraic definition of the dot product}.
+We will call this the \emph{algebraic definition of the dot product}\index{Dot product!algebraic definition}\index[definitions]{Dot product!algebraic definition}.
 
 By switching between algebraic and geometric definitions, we can use the dot
 product to find quantities that are otherwise difficult to find.
@@ -117,7 +117,7 @@ a right angle and the idea of one of them being $\vec 0$.
 
 \medskip
 Before we continue, let's pin down exactly what we mean by
-the \emph{direction}\index{Direction}\index{Vector!positive direction of} of a vector.
+the \emph{direction} of a vector.
 There are many ways we could define
 this term, but we'll go with the following.
 

--- a/book/modules/module6.tex
+++ b/book/modules/module6.tex
@@ -121,7 +121,7 @@ lines, planes, volumes and more.
 As mentioned earlier, subspaces and spans are deeply connected.
 This connection is given by the following theorem.
 
-\begin{theorem}(Subspace-Span)=
+\begin{theorem}[Subspace-Span]
 	Every subspace is a span and every span is a subspace.  More precisely,
 	$\mathcal V\subseteq \R^n$ is a subspace if and only if $\mathcal V=
 	\Span\mathcal X$ for some set $\mathcal X$.

--- a/book/modules/module6.tex
+++ b/book/modules/module6.tex
@@ -38,7 +38,7 @@ of linear combinations is still a linear combination, a span
 is \emph{closed} with respect to linear combinations. That is, 
 by taking linear combinations of vectors in a span, you cannot
 escape the span. In general, sets that have this property are called
-\emph{subspaces}\index{Subspace}.
+\emph{subspaces}.
 
 \SavedDefinitionRender{Subspace}
 
@@ -121,7 +121,7 @@ lines, planes, volumes and more.
 As mentioned earlier, subspaces and spans are deeply connected.
 This connection is given by the following theorem.
 
-\begin{theorem}(Subspace-Span)
+\begin{theorem}(Subspace-Span)\index{Subspace!Subspace-Span Theorem}\index{Span!Subspace-Span Theorem}
 	Every subspace is a span and every span is a subspace.  More precisely,
 	$\mathcal V\subseteq \R^n$ is a subspace if and only if $\mathcal V=
 	\Span\mathcal X$ for some set $\mathcal X$.

--- a/book/modules/module6.tex
+++ b/book/modules/module6.tex
@@ -121,7 +121,7 @@ lines, planes, volumes and more.
 As mentioned earlier, subspaces and spans are deeply connected.
 This connection is given by the following theorem.
 
-\begin{theorem}(Subspace-Span)\index{Subspace!Subspace-Span Theorem}\index{Span!Subspace-Span Theorem}
+\begin{theorem}(Subspace-Span)=
 	Every subspace is a span and every span is a subspace.  More precisely,
 	$\mathcal V\subseteq \R^n$ is a subspace if and only if $\mathcal V=
 	\Span\mathcal X$ for some set $\mathcal X$.

--- a/book/modules/module7.tex
+++ b/book/modules/module7.tex
@@ -20,7 +20,7 @@ We can rewrite \eqref{EQREGSYS} using matrix-vector multiplication:
 \[
 	\underbrace{\mat{1&2&-2\\2&1&-5\\1&-4&1}}_{A}\mat{x\\y\\z}=\mat{-15\\-21\\18}.
 \]
-The matrix $A$ on the left is called the \emph{coefficient matrix}\index{Coefficient matrix} because it
+The matrix $A$ on the left is called the \emph{coefficient matrix}\index{Matrix!coefficient matrix}\index[definitions]{Matrix!coefficient matrix}\index{System of linear equations!coefficient matrix}\index[definitions]{System of linear equations!coefficient matrix} because it
 is made up of the coefficients from equation \eqref{EQREGSYS}.
 
 \medskip
@@ -82,7 +82,7 @@ can be interpreted as the intersection of three planes (or hyperplanes if there 
 Each equation (each row) specifies a plane, and the solution set is the intersection of all of these planes.
 Rewriting a system of equations in matrix form gives two additional ways to interpret  the solution set.
 
-\Heading{The \emph{Column} Picture}
+\Heading{The \emph{Column} Picture}\index{Matrix equations!the column picture}
 
 Using the column interpretation of matrix-vector multiplication, we see that system \eqref{EQREGSYSb} is equivalent to
 \[
@@ -97,7 +97,7 @@ Here,
  $\mat{1\\2\\1}$, $\mat{2\\1\\-4}$, and $\mat{-2\\-5\\1}$ are the columns of the coefficient matrix.
 
 
-\Heading{The \emph{Row} Picture}
+\Heading{The \emph{Row} Picture}\index{Matrix equations!the row picture}
 The row interpretation gives another perspective. Let $\vec r_1$, $\vec r_2$, and $\vec r_3$ be the rows of the coefficient matrix
 for system \eqref{EQREGSYSb}. Then, system \eqref{EQREGSYSb} is equivalent to
 \[

--- a/book/modules/module7.tex
+++ b/book/modules/module7.tex
@@ -20,7 +20,7 @@ We can rewrite \eqref{EQREGSYS} using matrix-vector multiplication:
 \[
 	\underbrace{\mat{1&2&-2\\2&1&-5\\1&-4&1}}_{A}\mat{x\\y\\z}=\mat{-15\\-21\\18}.
 \]
-The matrix $A$ on the left is called the \emph{coefficient matrix}\index{Matrix!coefficient matrix}\index[definitions]{Matrix!coefficient matrix}\index{System of linear equations!coefficient matrix}\index[definitions]{System of linear equations!coefficient matrix} because it
+The matrix $A$ on the left is called the \emph{coefficient matrix}\index{Matrix!coefficient matrix}\index{System of linear equations!coefficient matrix} because it
 is made up of the coefficients from equation \eqref{EQREGSYS}.
 
 \medskip

--- a/book/modules/module8.tex
+++ b/book/modules/module8.tex
@@ -143,7 +143,7 @@ us---the distinction between an object and a representation of that object.
 \bigskip
 
 Let $\vec x=2\xhat+3\yhat\in \R^2$. The vector $\vec x$ is a \emph{real-life geometrical thing}, and to
-emphasize this, we will call $\vec x$ a \emph{true} vector. In contrast, when we write
+emphasize this, we will call $\vec x$ a \emph{true} vector\index{True vector}. In contrast, when we write
 the column matrix $[\vec x]_{\mathcal E}=\mat{2\\3}$, we are writing a \emph{list of numbers}. The list of
 numbers $\mat{2\\3}$ has no meaning until we give it a meaning by assigning it a basis. For example,
 by writing $\mat{2\\3}_{\mathcal E}$, we declare that the numbers $2$ and $3$ are the coefficients of $\xhat$ and
@@ -169,7 +169,7 @@ To help keep the notation straight in your head, for a basis $\mathcal X$, remem
 It's easy to get confused when answering questions that involve multiple bases; precision will
 make these problems much easier.
 
-\Heading{Orientation of a Basis}
+\Heading{Orientation of a Basis}\index{Basis!orientation of}
 How can you tell the difference between a hand and a foot? They're similar in structure\footnote{ We might
 say hands and feet are \emph{topologically} equivalent.}---a hand has five
 fingers and a foot has five toes---but they're different in shape---fingers are much longer than toes and the thumb sticks off


### PR DESCRIPTION
Comments:
1. In module 3 the word "volume" (as a higher dimensional generalization of plane) is highlighted, but there's no definition box associated to this term. I added the word "volume" to the index of terms (but not index of definitions).
2. Changed the entry "coefficient matrix" (appeared in Module 7) to "Matrix!coefficient matrix" and "System of linear equations!coefficient matrix".
3. The definition of "dot product" in definition.tex is referring to the algebraic definition (p.53). Thus, the definition entry referring to this is "Dot product!algebraic definition".
4.Pending review: entry "scalar product", "direction".
5.For some unknown reasons, "v comp" appears before "proj" in the index. (Perhaps because \Comp is before \Proj lexicographicly?)