### PR TITLE
Add index for Modules 9 through 16.

### DIFF
--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -403,7 +403,7 @@
 
 \begin{SaveDefinition}[key=LinearTransformation, title={Linear Transformation}]
 	Let $V$ and $W$ be subspaces. A function $T:V\to W$ is called a
-	\emph{linear transformation} if
+	\emph{linear transformation}\index[definitions]{Linear transformation} if
 	\[
 		T(\vec u+\vec v)=T(\vec u)+T(\vec v) \qquad\text{and}\qquad T(\alpha
 		\vec v)=\alpha T(\vec v)
@@ -413,7 +413,7 @@
 
 \begin{SaveDefinition}[key=ImageofaSet, title={Image of a Set}]
 	Let $L:\R^n\to \R^m$ be a transformation and let $X\subseteq \R^n$ be a set. The
-	\emph{image of the set $X$ under $L$}, denoted $L(X)$, is the set
+	\emph{image of the set $X$ under $L$}\index[definitions]{Set!image of}, denoted $L(X)$, is the set
 	\[
 		L(X)=\Set{\vec y\in \R^m \given \vec y=L(\vec x)\text{ for some }\vec
 		x\in X}.
@@ -421,7 +421,7 @@
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=CompositionofFunctions, title={Composition of Functions}]
-	Let $f:A\to B$ and $g:B\to C$. The \emph{composition} of $g$ and $f$, notated $g\circ f$,
+	Let $f:A\to B$ and $g:B\to C$. The \emph{composition} of $g$ and $f$, notated $g\circ f$\index[symbols]{$g \circ f$}\index[definitions]{Linear transformation!composition of},
 	is the function $h:A\to C$ defined by
 	\[
 		h(x)=g\circ f(x) = g\Big(f(x)\Big).
@@ -431,7 +431,7 @@
 \begin{SaveDefinition}[key=Range, title={Range}]
 	The
 	\emph{range} (or
-	\emph{image}) of a linear transformation $T:V\to W$ is the set of vectors
+	\emph{image})\index[definitions]{Range}\index[symbols]{$\Range(T)$} of a linear transformation $T:V\to W$ is the set of vectors
 	that $T$ can output. That is,
 	\[
 		\Range(T)=\Set{\vec y\in W \given \vec y=T\vec x\text{ for some }\vec
@@ -443,7 +443,7 @@
 \begin{SaveDefinition}[key=NullSpace, title={Null Space}]
 	The
 	\emph{null space} (or
-	\emph{kernel}) of a linear transformation $T:V\to W$ is the set of vectors
+	\emph{kernel})\index[definitions]{Null space!of a linear transformation}\index[symbols]{$\Null(T)$} of a linear transformation $T:V\to W$ is the set of vectors
 	that get mapped to the zero vector under $T$. That is,
 	\[
 		\Null(T)=\Set{\vec x\in V \given T\vec x=\vec 0}.
@@ -455,7 +455,7 @@
 	key=InducedTransformation,
 	title={Induced Transformation}]
 
-	Let $M$ be an $n\times m$ matrix. We say $M$
+	Let $M$ be an $n\times m$ matrix. We say $M$\index[definitions]{Linear transformation! matrix representation of}
 	\emph{induces} a linear transformation $\mathcal T_{M}:\R^{m}\to\R^{n}$ defined
 	by
 	\[
@@ -477,7 +477,7 @@
 		\vdots &\vdots&\vdots &\ddots&\vdots\\
 		a_{n1}&a_{n2}&a_{n3}&\cdots&a_{nm}}.
 	\]
-	The \emph{transpose} of $M$, notated $M^T$, is the $m\times n$ matrix produced by swapping the rows
+	The \emph{transpose} of $M$\index[definitions]{Transpose}, notated $M^T$, is the $m\times n$ matrix produced by swapping the rows
 	and columns of $M$. That is
 	\[
 		M^T=\matc{
@@ -493,14 +493,14 @@
 	key=ElementaryMatrix,
 	title={Elementary Matrix}]
 
-	A matrix is called an \emph{elementary matrix} if it is an identity matrix with a single elementary row operation applied.
+	A matrix is called an \emph{elementary matrix}\index[definitions]{Matrix!elementary matrix} if it is an identity matrix with a single elementary row operation applied.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
 	key=MatrixInverse,
 	title={Matrix Inverse}]
 		
-	The \emph{inverse} of a matrix $A$ is a
+	The \emph{inverse}\index[definitions]{Inverse!of a matrix} of a matrix $A$ is a
 		matrix $B$ such that $AB=I$ and $BA=I$.
 		In this case, $B$ is called the inverse of $A$ and is notated $A^{-1}$.
 \end{SaveDefinition}
@@ -509,8 +509,8 @@
 	key=IdentityFunction,
 	title={Identity Function}]
 	
-	Let $X$ be a set. The \emph{identity function} with domain and codomain $X$,
-	notated $\Ident:X\to X$, is the function satisfying
+	Let $X$ be a set. The \emph{identity function}\index[definitions]{Identity!function} with domain and codomain $X$,
+	notated $\Ident:X\to X$\index[symbols]{$\Ident(x)$}, is the function satisfying
 	\[
 		\Ident(x)=x
 	\]
@@ -523,7 +523,7 @@
 		
 	Let $f:X\to Y$ be a function. We say $f$ is \emph{invertible} if
 	there exists a function $g:Y\to X$ so that $f\circ g=\Ident$ and $g\circ f=\Ident$.
-	In this case, we call $g$ an \emph{inverse} of $f$ and write
+	In this case, we call $g$ an \emph{inverse}\index[definitions]{Inverse!of a function}\index[symbols]{$f^{-1}$} of $f$ and write
 	\[
 		f^{-1}=g.
 	\]
@@ -533,7 +533,7 @@
 	key=Onetoone,
 	title={One-to-one}]
 		
-	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one} (or \emph{injective}) if
+	Let $f:X\to Y$ be a function. We say $f$ is \emph{one-to-one} (or \emph{injective})\index[definitions]{One-to-one} if
 	distinct inputs to $f$ produce distinct outputs. That is $f(x)=f(y)$ implies $x=y$.
 \end{SaveDefinition}
 
@@ -542,7 +542,7 @@
 	title={Onto}]
 		
 	Let $f:X\to Y$ be a function.
-	We say $f$ is \emph{onto} (or \emph{surjective}) if every point in the codomain of $f$ gets mapped to.
+	We say $f$ is \emph{onto} (or \emph{surjective})\index[definitions]{Onto} if every point in the codomain of $f$ gets mapped to.
 	That is $\Range(f)=Y$.
 \end{SaveDefinition}
 
@@ -550,36 +550,36 @@
 	key=IdentityMatrix,
 	title={Identity Matrix}]
 	
-	An \emph{identity matrix} is a square matrix with ones on the diagonal
-	and zeros everywhere else. The $n\times n$ identity matrix is denoted $I_{n\times n}$,
+	An \emph{identity matrix}\index[definitions]{Identity!matrix} is a square matrix with ones on the diagonal
+	and zeros everywhere else. The $n\times n$ identity matrix is denoted $I_{n\times n}$\index[symbols]{$I_{n\times n}$},
 	or just $I$ when its size is implied.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=FundamentalSubspaces, title={Fundamental Subspaces}]
-	Associated with any matrix $M$ are three fundamental subspaces: the
-	\emph{row space} of $M$, denoted $\Row(M)$, is the span of the rows of
+	Associated with any matrix $M$ are three fundamental subspaces\index[definitions]{Fundamental subspaces of a matrix}: the
+	\emph{row space}\index[definitions]{Row space}\index[symbols]{$\Row(M)$} of $M$, denoted $\Row(M)$, is the span of the rows of
 	$M$; the
-	\emph{column space} of $M$, denoted $\Col(M)$, is the span of the
+	\emph{column space}\index[definitions]{Column space}\index[symbols]{$\Col(M)$} of $M$, denoted $\Col(M)$, is the span of the
 	columns of $M$; and the
-	\emph{null space} of $M$, denoted $\Null(M)$, is the set of solutions to
+	\emph{null space}\index[definitions]{Null space!of a matrix}\index[symbols]{$\Null(M)$} of $M$, denoted $\Null(M)$, is the set of solutions to
 	$M\vec x=\vec 0$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=RankofaLinearTransformation, title={Rank of a Linear Transformation}]
 	For a linear transformation $T:\R^n\to \R^m$, the
-	\emph{rank} of $T$, denoted $\Rank(T)$, is the dimension of the range of
+	\emph{rank} of $T$\index[definitions]{Rank!of a linear transformation}, denoted $\Rank(T)$, is the dimension of the range of
 	$T$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=RankofaMatrix, title={Rank of a Matrix}]
 	Let $M$ be a matrix.
-	The \emph{rank} of $M$, denoted $\Rank(M)$, is the rank of
+	The \emph{rank} of $M$\index[definitions]{Rank!of a matrix}, denoted $\Rank(M)$, is the rank of
 	the linear transformation induced by $M$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=NullityofaMatrix, title={Nullity of a Matrix}]
 	Let $M$ be a matrix.
-	The \emph{nullity} of $M$, denoted $\Nullity(M)$, is the nullity of
+	The \emph{nullity}\index[definitions]{Nullity!of a matrix} of $M$, denoted $\Nullity(M)$, is the nullity of
 	the linear transformation induced by $M$.
 \end{SaveDefinition}
 
@@ -595,13 +595,13 @@
 
 \begin{SaveDefinition}[key=Nullity, title={Nullity}]
 	For a linear transformation $T:\R^n\to \R^m$, the
-	\emph{nullity} of $T$, denoted $\Nullity(T)$, is the dimension of the null space of
+	\emph{nullity} of $T$\index[definitions]{Nullity!of a linear transformation}, denoted $\Nullity(T)$, is the dimension of the null space of
 	$T$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=ChangeofBasisMatrix, title={Change of Basis Matrix}]
 	Let $\mathcal A$ and $\mathcal B$ be bases for $\R^n$. The matrix $M$ is called
-	a \emph{change of basis} matrix (which converts from $\mathcal A$ to $\mathcal B$) if
+	a \emph{change of basis} matrix\index[definitions]{Change of basis matrix} (which converts from $\mathcal A$ to $\mathcal B$) if
 	for all $\vec x\in \R^n$
 	\[
 		M[\vec x]_{\mathcal A}=[\vec x]_{\mathcal B}.
@@ -613,19 +613,19 @@
 
 \begin{SaveDefinition}[key=LinearTransformationinaBasis, title={Linear Transformation in a Basis}]
 	Let $\mathcal T:\R^n\to\R^n$ be a linear transformation and let $\mathcal B$ be a
-	basis for $\R^n$. The \emph{matrix for $\mathcal T$ with respect to $\mathcal B$}, notated
+	basis for $\R^n$. The \emph{matrix for $\mathcal T$ with respect to $\mathcal B$}\index[definitions]{Linear transformation! matrix representation of}, notated
 	$[\mathcal T]_{\mathcal B}$,
 	is the $n\times n$ matrix satisfying
 	\[
 		[\mathcal T\vec x]_{\mathcal B} = [\mathcal T]_{\mathcal B}[\vec x]_{\mathcal B}.
 	\]
-	In this case, we say the matrix $[\mathcal T]_{\mathcal B}$ is the representation
+	In this case, we say the matrix $[\mathcal T]_{\mathcal B}$\index[symbols]{$[\mathcal T]_{\mathcal B}$} is the representation
 	of $\mathcal T$ in the $\mathcal B$ basis.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=SimilarMatrices, title={Similar Matrices}]
 	The matrices $A$ and $B$ are called
-	\emph{similar matrices}, denoted $A\sim B$, if $A$ and $B$ represent the
+	\emph{similar matrices}\index[definitions]{Matrix!similar matrices}, denoted $A\sim B$\index[symbols]{$\sim$}, if $A$ and $B$ represent the
 	same linear transformation but in possibly different bases. Equivalently,
 	$A\sim B$ if there is an invertible matrix $X$ so that
 	\[
@@ -636,7 +636,7 @@
 
 \begin{SaveDefinition}[key=Unitncube, title={Unit $n$-cube}]
 	The
-	\emph{unit $n$-cube} is the $n$-dimensional cube with sides given by the
+	\emph{unit $n$-cube}\index[definitions]{Unit $n$-cube} is the $n$-dimensional cube with sides given by the
 	standard basis vectors and lower-left corner located at the origin. That
 	is
 	\[
@@ -648,14 +648,14 @@
 
 \begin{SaveDefinition}[key=Determinant, title={Determinant}]
 	The
-	\emph{determinant} of a linear transformation $X:\R^{n}\to \R^{n}$, denoted $\det(X)$ or $\Abs{X}$, is
+	\emph{determinant}\index[definitions]{Determinant} of a linear transformation $X:\R^{n}\to \R^{n}$, denoted $\det(X)$\index[symbols]{$\det(X)$} or $\Abs{X}$, is
 	the oriented volume of the image of the unit $n$-cube. The determinant of
 	a square matrix is the determinant of its induced transformation.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=OrientationPreservingLinearTransformation, title={Orientation Preserving Linear Transformation}]
 	Let $\mathcal T:\R^n\to\R^n$ be a linear transformation. We say $\mathcal T$
-	is \emph{orientation preserving} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
+	is \emph{orientation preserving}\index[definitions]{Linear transformation!orientation preserving/reversing} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
 	is positively oriented  and we say $\mathcal T$
 	is \emph{orientation reversing} if the ordered basis $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
 	is negatively oriented. If $\Set{\mathcal T(\vec e_1),\ldots, \mathcal T(\vec e)}$
@@ -664,14 +664,14 @@
 
 \begin{SaveDefinition}[key=Eigenvector, title={Eigenvector}]
 	Let $X$ be a linear transformation or a matrix. An
-	\emph{eigenvector} for $X$ is a non-zero vector that doesn't change
+	\emph{eigenvector}\index[definitions]{Eigenvector} for $X$ is a non-zero vector that doesn't change
 	directions when $X$ is applied. That is, $\vec v\neq \vec 0$ is an
 	eigenvector for $X$ if
 	\[
 		X\vec v=\lambda \vec v
 	\]
 	 for some scalar $\lambda$. We call $\lambda$ the
-	\emph{eigenvalue} of $X$ corresponding to the eigenvector $\vec v$.
+	\emph{eigenvalue}\index[definitions]{Eigenvalue} of $X$ corresponding to the eigenvector $\vec v$.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[
@@ -679,7 +679,7 @@
 	title={Characteristic Polynomial}]
 
 	For a matrix $A$, the
-	\emph{characteristic polynomial} of $A$ is
+	\emph{characteristic polynomial}\index[definitions]{Characteristic polynomial}\index[symbols]{$\chr(A)$} of $A$ is
 	\[
 		\chr(A)=\det(A-\lambda I).
 	\]
@@ -688,21 +688,21 @@
 
 \begin{SaveDefinition}[key=Diagonalizable, title={Diagonalizable}]
 	A matrix is
-	\emph{diagonalizable} if it is similar to a diagonal matrix.
+	\emph{diagonalizable}\index[definitions]{Diagonalizable} if it is similar to a diagonal matrix.
 \end{SaveDefinition}
 
 \begin{SaveDefinition}[key=Eigenspace, title={Eigenspace}]
 	Let $A$ be an $n\times n$ matrix with eigenvalues
 	$\lambda_{1},\ldots,\lambda_{m}$. The
-	\emph{eigenspace} of $A$ corresponding to the eigenvalue $\lambda_{i}$
+	\emph{eigenspace}\index[definitions]{Eigenspace} of $A$ corresponding to the eigenvalue $\lambda_{i}$
 	is the null space of $A-\lambda_{i} I$. That is, it is the space spanned
 	by all eigenvectors that have the eigenvalue $\lambda_{i}$.
 
 	The
-	\emph{geometric multiplicity} of an eigenvalue $\lambda_{i}$ is the
+	\emph{geometric multiplicity}\index[definitions]{Eigenvalue!geometric multiplicity} of an eigenvalue $\lambda_{i}$ is the
 	dimension of the corresponding eigenspace. The
-	\emph{algebraic multiplicity} of $\lambda_{i}$ is the number of times
-	$\lambda_{i}$ occurs as a root of the characteristic polynomial of $A$ (i.e.,
+	\emph{algebraic multiplicity}\index[definitions]{Eigenvalue!algebraic multiplicity} of $\lambda_{i}$ is the number of times
+	$\lambda_{i}$ occurs as a root of the characteristic polynomial\index{Characteristic polynomial} of $A$ (i.e.,
 	the number of times $x-\lambda_{i}$ occurs as a factor).
 \end{SaveDefinition}
 

--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -455,7 +455,7 @@
 	key=InducedTransformation,
 	title={Induced Transformation}]
 
-	Let $M$ be an $n\times m$ matrix. We say $M$\index[definitions]{Linear transformation! matrix representation of}
+	Let $M$ be an $n\times m$ matrix. We say $M$\index[definitions]{Linear transformation!matrix representation of}
 	\emph{induces} a linear transformation $\mathcal T_{M}:\R^{m}\to\R^{n}$ defined
 	by
 	\[

--- a/book/modules/module10.tex
+++ b/book/modules/module10.tex
@@ -110,7 +110,7 @@ Thus $M_AM_B$ must be a matrix for $\mathcal A\circ \mathcal B=\mathcal T$. Inde
 \[
 	M_AM_B=\mat{1&2\\0&2}\mat{-1&-1\\-2&0}=\mat{-5&-1\\-4&0}=M_T.
 \]
-The fact that matrix multiplication corresponds to function composition is no coincidence. It is the very
+The fact that matrix multiplication\index{Matrix!matrix multiplication} corresponds to function composition is no coincidence. It is the very
 reason matrix multiplication is defined the way it is. This is reiterated in the following theorem.
 
 \begin{theorem}

--- a/book/modules/module11.tex
+++ b/book/modules/module11.tex
@@ -13,7 +13,7 @@ is always a subspace.
 
 \begin{theorem}
 	Let $T:\R^n\to\R^m$ be a linear transformation. Then $\Range(T)\subseteq \R^m$ is a
-	subspace.
+	subspace\index{Subspace}.
 \end{theorem}
 \begin{proof}
 	Since $\Range(T)=T(\R^n)$ and $\R^n$ is non-empty, we know that $\Range(T)$ is non-empty.
@@ -38,7 +38,7 @@ is always a subspace.
 \end{proof}
 
 When analyzing subspaces, we are often interested in how big they are. That information is captured by a number---the
-\emph{dimension} of the subspace. For transformations, we also have a notion of how ``big'' they are, which is captured
+\emph{dimension}\index{Dimension} of the subspace. For transformations, we also have a notion of how ``big'' they are, which is captured
 in a number called the \emph{rank}.
 
 \SavedDefinitionRender{RankofaLinearTransformation}
@@ -197,7 +197,7 @@ In addition, it helps us state the following theorem.
 \end{theorem}
 \begin{proof}
 	To prove $\Rank(A)=\Rank(A^T)$, we will rely on what we know about the row reduction algorithm and what
-	the reduced row echelon form of a matrix tells us.
+	the reduced row echelon form\index{Matrix!reduced row echelon form} of a matrix tells us.
 
 	\emph{Claim 1}: $\Row(\Rref(A))\subseteq \Row(A)$. To see this, observe that to get $\Rref(A)$, we take
 	linear combinations of the rows of $A$. Therefore, it must be that the span of the rows of $\Rref(A)$
@@ -492,7 +492,7 @@ $\Null(\mathcal T)=\Null(M)$. From this fact, we deduce the following theorem.
 
 The rank and the nullity of a linear transformation/matrix are connected by a powerful theorem.
 
-\begin{theorem}(Rank-nullity Theorem for Matrices) For a matrix $A$,
+\begin{theorem}(Rank-nullity Theorem for Matrices)\index{Rank-nullity theorem!for matrices} For a matrix $A$,
 \[
 	\Rank(A)+\Nullity(A)=\ \#\text{ of columns in $A$}.
 \]
@@ -513,7 +513,7 @@ and so has nullity $2$. Therefore, there exist two linearly independent normal d
 
 \medskip
 There is an equivalent Rank-nullity Theorem for linear transformations.
-\begin{theorem}(Rank-nullity Theorem for Linear Transformations) Let $\mathcal T$ be a linear transformation.
+\begin{theorem}(Rank-nullity Theorem for Linear Transformations)\index{Rank-nullity theorem!for linear transformations} Let $\mathcal T$ be a linear transformation.
 Then
 \[
 	\Rank(\mathcal T)+\Nullity(\mathcal T)=\Dim(\text{domain of $\mathcal T$}).

--- a/book/modules/module12.tex
+++ b/book/modules/module12.tex
@@ -73,7 +73,7 @@ Now, suppose $\mathcal T$ is one-to-one and onto. By the Rank-nullity Theorem,
 \]
 and so $\mathcal T$ has the same domain and codomain (at least a domain and codomain of the same dimension).
 
-Using the rank-nullity theorem, we can start developing a list of properties that are equivalent to invertibility of a
+Using the rank-nullity theorem\index{Rank-nullity theorem!for linear transformations}, we can start developing a list of properties that are equivalent to invertibility of a
 linear transformation.
 \begin{itemize}
 	\item $\mathcal T:\R^n\to\R^m$ is invertible if and only if $\Nullity(\mathcal T)=0$ and $\Rank(\mathcal T)=m$.
@@ -306,7 +306,7 @@ that turn $M$ into $I$. Each one of these row operations can be represented by a
 following theorem.
 
 \begin{theorem}
-	A matrix $M$ is invertible if and only if there are elementary matrices $E_1,\ldots, E_k$ so that
+	A matrix $M$ is invertible\index{Matrix!invertible} if and only if there are elementary matrices $E_1,\ldots, E_k$ so that
 	\[
 		E_k\cdots E_2E_1M=I.
 	\]

--- a/book/modules/module13.tex
+++ b/book/modules/module13.tex
@@ -1,7 +1,7 @@
 
 Given a basis $\mathcal A$ for $\R^n$, every  vector $\vec x\in\R^n$ uniquely
 corresponds to the list of numbers $[\vec x]_{\mathcal A}$ (its coordinates with respect
-to $\mathcal A$), and  the operation of writing a vector in a basis is \emph{invertible}.
+to $\mathcal A$), and  the operation of writing a vector in a basis is \emph{invertible}\index{Invertible}.
 
 If we have two bases, $\mathcal A$ and $\mathcal B$, for $\R^n$, we have two equally valid
 ways of representing a vector in coordinates.
@@ -122,7 +122,7 @@ take vectors and rewrite them in the same basis, which is to say, they do nothin
 The argument above shows that every change of basis matrix is invertible. The converse is also true.
 
 \begin{theorem}
-	An $n\times n$ matrix is invertible if and only if it is a change of basis matrix.
+	An $n\times n$ matrix is invertible\index{Matrix!invertible} if and only if it is a change of basis matrix.
 \end{theorem}
 \begin{proof}
 	Suppose $M=\BasisChange{\mathcal A}{\mathcal B}$ is a change-of-basis matrix. Then

--- a/book/modules/module13.tex
+++ b/book/modules/module13.tex
@@ -1,7 +1,7 @@
 
 Given a basis $\mathcal A$ for $\R^n$, every  vector $\vec x\in\R^n$ uniquely
 corresponds to the list of numbers $[\vec x]_{\mathcal A}$ (its coordinates with respect
-to $\mathcal A$), and  the operation of writing a vector in a basis is \emph{invertible}\index{Invertible}.
+to $\mathcal A$), and  the operation of writing a vector in a basis is \emph{invertible}.
 
 If we have two bases, $\mathcal A$ and $\mathcal B$, for $\R^n$, we have two equally valid
 ways of representing a vector in coordinates.

--- a/book/modules/module14.tex
+++ b/book/modules/module14.tex
@@ -80,7 +80,7 @@ changes area/volume. This number (which is associated with a linear transformati
 the same domain and codomain) is called the \emph{determinant}\footnote{ This number is \emph{almost} the determinant.
 The only difference is that the determinant might have a $\pm$ in front.}.
 
-\Heading{Volumes}
+\Heading{Volumes}\index{Volume}
 
 In this module, most examples will be in $\R^2$ because they're easier to draw.
 The definitions given will extend to $\R^n$ for any $n$, however we need to establish some conventions
@@ -691,7 +691,7 @@ orientation preserving and $-\Vol\mathcal Q(X)$ if $\mathcal Q$ is orientation r
 \end{example}
 
 
-\Heading{Determinants of Composition}
+\Heading{Determinants of Composition}\index{Linear transformation!composition of}
 
 Volume changes are naturally multiplicative. If a linear transformation $\mathcal T$ changes volume by a factor
 of $\alpha$ and $\mathcal S$ changes volume by a factor of $\beta$, then $\mathcal S\circ \mathcal T$ changes
@@ -822,7 +822,7 @@ to show that the composition of two orientation-reversing transformations is ori
 This means that we can compute the determinant of a complicated transformation by breaking it up
 into simpler ones and computing the determinant of each piece. 
 
-\Heading{Determinants of Matrices}
+\Heading{Determinants of Matrices}\index{Matrix!elementary matrices}
 
 The determinant of a matrix is defined as the determinant of its induced transformation.
 That means, the determinant is multiplicative with respect to matrix multiplication (because
@@ -965,7 +965,7 @@ Therefore, the volume of the parallelepiped given by the columns of $M$ must be 
 
 Based on this argument, we have the following theorem.
 \begin{theorem}
-	Let $A$ be an $n\times n$ matrix. $A$ is invertible if and only if $\det(A)\neq 0$.
+	Let $A$ be an $n\times n$ matrix. $A$ is invertible\index{Matrix!invertible} if and only if $\det(A)\neq 0$.
 \end{theorem}
 \begin{proof}
 	If $A$ is invertible, $A=E_1\cdots E_k$, where $E_1,\ldots,E_k$ are elementary matrices,
@@ -998,7 +998,7 @@ which gives
 \Heading{Determinants and Transposes}
 
 Somewhat mysteriously, we have the following theorem.
-\begin{theorem}[Volume Theorem II]
+\begin{theorem}(Volume Theorem II)
 	The determinant of a square matrix $A$ is equal to the oriented volume of the parallelepiped
 	given by the rows of $A$.
 \end{theorem}

--- a/book/modules/module14.tex
+++ b/book/modules/module14.tex
@@ -998,7 +998,7 @@ which gives
 \Heading{Determinants and Transposes}
 
 Somewhat mysteriously, we have the following theorem.
-\begin{theorem}(Volume Theorem II)
+\begin{theorem}[Volume Theorem II]
 	The determinant of a square matrix $A$ is equal to the oriented volume of the parallelepiped
 	given by the rows of $A$.
 \end{theorem}

--- a/book/modules/module15.tex
+++ b/book/modules/module15.tex
@@ -97,7 +97,7 @@ Now we have that $\vec v\neq \vec 0$ is an eigenvector for $M$ if and only if
 \]
 or, phrased another way, $\vec v$ is a non-zero vector satisfying $\vec v\in \Null(E_\lambda)$.
 
-We've reduced the problem of finding eigenvectors/values of $M$ to finding the null space of $E_\lambda$,
+We've reduced the problem of finding eigenvectors/values of $M$ to finding the null space\index{Null space} of $E_\lambda$,
 a related matrix.
 
 \Heading{Characteristic Polynomial}
@@ -213,7 +213,7 @@ stubborn polynomials.
 	are the non-zero multiples of $\matc{\frac{3-\sqrt{33}}{6}\\-1}$.
 \end{example}
 
-\Heading{Transformations without Eigenvectors}
+\Heading{Transformations without Eigenvectors}\index{Linear transformation}
 
 Are there linear transformations without eigenvectors? Well, it
 depends on exactly what you mean. Let $\mathcal R:\R^2\to\R^2$

--- a/book/modules/module16.tex
+++ b/book/modules/module16.tex
@@ -39,7 +39,7 @@ are equally valid, but writing $\mathcal T$ in the $\mathcal V$ basis gives a ve
 
 \Heading{Diagonalization}
 
-Recall that two matrices are similar if they represent the same transformation but in possibly different bases.
+Recall that two matrices are similar\index{Matrix!similar matrices} if they represent the same transformation but in possibly different bases.
 The process of \emph{diagonalizing} a matrix $A$ is that of finding a diagonal matrix that is similar to $A$,
 and you can bet that this process is closely related to eigenvectors/values.
 
@@ -88,8 +88,8 @@ which is a diagonal matrix.
 What we've shown is summarized by the following theorem.
 \begin{theorem}
 	A linear transformation $\mathcal T:\R^n\to\R^n$ can be represented by a diagonal matrix if and
-	only if there exists a basis for $\R^n$ consisting of eigenvectors for $\mathcal T$. If
-	$\mathcal B$ is such a basis, then $[\mathcal T]_{\mathcal B}$ is a diagonal matrix.
+	only if there exists a basis for $\R^n$ consisting of eigenvectors\index{Eigenvector} for $\mathcal T$. If
+	$\mathcal B$ is such a basis, then $[\mathcal T]_{\mathcal B}$ is a diagonal matrix\index{Matrix!diagonal matrix}.
 \end{theorem}
 
 Now that we have a handle on representing a linear transformation by a diagonal matrix, let's tackle
@@ -108,7 +108,7 @@ In other words, $A$ and $B$ are similar if there is some invertible change-of-ba
 \[
 	A=PBP^{-1}.
 \]
-Based on our earlier discussion, $B$ will be a diagonal matrix if and only if $P$ is the change-of-basis matrix for a
+Based on our earlier discussion, $B$ will be a diagonal matrix if and only if $P$ is the change-of-basis\index{Basis!change-of-basis} matrix for a
 basis of eigenvectors. In this case, we know $B$ will be the diagonal matrix with eigenvalues along the diagonal (in the proper order).
 
 \begin{example}
@@ -148,7 +148,7 @@ A\vec v_1=\matc{20\\20\\4}=4\vec v_1,\qquad A\vec v_2=\mat{8\\8\\8}=8\vec v_2,\q
 \Heading{Non-diagonalizable Matrices}
 
 Is every matrix diagonalizable? Unfortunately the world is not that sweet. But, we have a tool to tell if a matrix is
-diagonalizable---checking to see if there is a basis of eigenvectors.
+diagonalizable\index{Diagonalizable}---checking to see if there is a basis of eigenvectors.
 
 \begin{example}
 	Is the matrix $R=\mat{0&-1\\1&0}$ diagonalizable?

--- a/book/modules/module9.tex
+++ b/book/modules/module9.tex
@@ -483,7 +483,7 @@ In other words, $T$ \emph{distributes over linear combinations}.
 	Since at least one required property of a linear transformation is violated, $\mathcal T$ cannot be a linear transformation.
 \end{example}
 
-\Heading{Function Notation vs\mbox{.} Linear Transformation Notation}
+\Heading{Function Notation vs\mbox{.} Linear Transformation Notation}\index{Linear transformation!notation}
 
 Linear transformations are just special types of functions. In calculus, it is traditional to use lower case
 letters for a function and parenthesis ``('' and ``)'' around the input to the function.
@@ -598,7 +598,7 @@ a linear transformation.
 Let's prove some basic facts about linear transformations.
 
 \begin{theorem}
-	If $T:\R^n\to\R^m$ is a linear transformation, then $T(\vec 0)=\vec 0$.
+	If $T:\R^n\to\R^m$ is a linear transformation, then $T(\vec 0)=\vec 0$\index{Zero vector ($\vec 0$)}.
 \end{theorem}
 \begin{proof}
 	Suppose $T:\R^n\to\R^m$ is a linear transformation and $\vec v\in \R^n$. We know
@@ -723,7 +723,7 @@ all vectors at once while (ii) having named vectors that we can actually use in 
 
 
 \begin{emphbox}[Takeaway]
-	Starting a linearity proof with ``\emph{let $\vec x,\vec y\in \R^n$ and let $\alpha$ be a scalar}''
+	Starting a linearity proof\index{Linear transformation!proving linearity} with ``\emph{let $\vec x,\vec y\in \R^n$ and let $\alpha$ be a scalar}''
 	allows you to argue about all vectors and scalars simultaneously.
 \end{emphbox}
 
@@ -785,7 +785,7 @@ we can think of multiplication by $M$ as a transformation on $\R^2$. Define
 \[
 	T:\R^2\to\R^2\qquad\text{by}\qquad T(\vec x)=M\vec x.
 \]
-Because $T$ is defined by a matrix, we call $T$ a \emph{matrix transformation}.
+Because $T$ is defined by a matrix, we call $T$ a \emph{matrix transformation}\index{Matrix!matrix transformation}.
 It turns out all matrix transformations are linear transformations and most linear transformations
 are matrix transformations\footnote{ If you believe in the axiom of choice and you allow infinitely sized matrices,
 every linear transformation can be expressed as a matrix transformation.}. 
@@ -819,7 +819,7 @@ For a matrix $M$, the following are correct.
 
 \Heading{Finding a Matrix for a Linear Transformation}
 
-Every linear transformation from $\R^n$ to $\R^m$ has a matrix, and we can use basic algebra to find
+Every linear transformation from $\R^n$ to $\R^m$ has a matrix\index{Linear transformation!matrix representation of}, and we can use basic algebra to find
 an appropriate matrix.
 
 Let $T:\R^n\to\R^m$ be a linear transformation. Since $T$ inputs vectors with $n$ coordinates and outputs


### PR DESCRIPTION
- definition indices moved from modules to definitions.tex
- added more symbols
- Rank-nullity theorem capitalization executive action not yet implemented (coming soon)

![2020-06-19 (22:51-34)](https://user-images.githubusercontent.com/48996448/85189859-ad396800-b280-11ea-8710-3ee671f78898.png)
