### PR TITLE
Consistent capitalization of 'rank-nullity theorem' and change one sentence.

### DIFF
--- a/book/common/definitions.tex
+++ b/book/common/definitions.tex
@@ -647,7 +647,7 @@
 
 \begin{SaveDefinition}[key=Determinant, title={Determinant}]
 	The
-	\emph{determinant}\index{Determinant}\index[definitions]{Determinant} of a linear transformation $X:\R^{n}\to \R^{n}$, denoted $\det(X)$\index[symbols]{$\det(X)$} or $\Abs{X}$\index[symbols]{$\Abs{X}$}, is
+	\emph{determinant}\index{Determinant}\index[definitions]{Determinant} of a linear transformation $\mathcal T:\R^{n}\to \R^{n}$, denoted $\det(\mathcal T)$\index[symbols]{$\det(\mathcal T)$} or $\Abs{\mathcal T}$\index[symbols]{$\Abs{\mathcal T}$}, is
 	the oriented volume of the image of the unit $n$-cube. The determinant of
 	a square matrix is the determinant of its induced transformation.
 \end{SaveDefinition}

--- a/book/modules/module11-exercises.tex
+++ b/book/modules/module11-exercises.tex
@@ -74,7 +74,7 @@
 
 					$\implies \Dim \Range(T) = \Rank(T)=2$
 
-				\item By rank-nullity theorem, $\Rank(T)+\Nullity(T) =
+				\item By the rank-nullity theorem, $\Rank(T)+\Nullity(T) =
 					\Dim(\text{domain of }T)$
 					\[
 						\implies 2+\Nullity(T)=3 \implies \Nullity(T)=1

--- a/book/modules/module11-exercises.tex
+++ b/book/modules/module11-exercises.tex
@@ -74,7 +74,7 @@
 
 					$\implies \Dim \Range(T) = \Rank(T)=2$
 
-				\item By Rank-Nullity theorem, $\Rank(T)+\Nullity(T) =
+				\item By rank-nullity theorem, $\Rank(T)+\Nullity(T) =
 					\Dim(\text{domain of }T)$
 					\[
 						\implies 2+\Nullity(T)=3 \implies \Nullity(T)=1

--- a/book/modules/module11.tex
+++ b/book/modules/module11.tex
@@ -498,7 +498,7 @@ The rank and the nullity of a linear transformation/matrix are connected by a po
 \]
 \end{theorem}
 
-The Rank-nullity Theorem's statement is simple, but it is surprisingly useful. Consider
+The rank-nullity theorem is a simple statement, but it is surprisingly useful. Consider
 the matrix \[M=\mat{1&2&2}.\] We already know that $\Null(M)$ is the plane with equation
 $x+2y+2z=0$ and therefore is two dimensional. Since $M$ has three columns, $\Rank(M)=1$, and
 so $\Dim(\Col(M))=\Dim(\Row(M))=1$, which means that $M$ has a one-dimensional set of normal vectors
@@ -512,7 +512,7 @@ How many normal vectors does $\mathcal P$ have? Well, the matrix $A=\mat{1&2&2&2
 and so has nullity $2$. Therefore, there exist two linearly independent normal directions for $\mathcal P$.
 
 \medskip
-There is an equivalent Rank-nullity Theorem for linear transformations.
+There is an equivalent rank-nullity theorem for linear transformations.
 \begin{theorem}(Rank-nullity Theorem for Linear Transformations)\index{Rank-nullity theorem!for linear transformations} Let $\mathcal T$ be a linear transformation.
 Then
 \[
@@ -520,5 +520,5 @@ Then
 \]
 \end{theorem}
 
-Just like the Rank-nullity Theorem for matrices, the Rank-nullity Theorem for linear transformations
+Just like the rank-nullity theorem for matrices, the rank-nullity theorem for linear transformations
 can give insights about linear transformations that would be otherwise hard to see.

--- a/book/modules/module11.tex
+++ b/book/modules/module11.tex
@@ -498,7 +498,7 @@ The rank and the nullity of a linear transformation/matrix are connected by a po
 \]
 \end{theorem}
 
-The rank-nullity theorem is a simple statement, but it is surprisingly useful. Consider
+The rank-nullity theorem's statement is simple, but it is surprisingly useful. Consider
 the matrix \[M=\mat{1&2&2}.\] We already know that $\Null(M)$ is the plane with equation
 $x+2y+2z=0$ and therefore is two dimensional. Since $M$ has three columns, $\Rank(M)=1$, and
 so $\Dim(\Col(M))=\Dim(\Row(M))=1$, which means that $M$ has a one-dimensional set of normal vectors

--- a/book/modules/module12-exercises.tex
+++ b/book/modules/module12-exercises.tex
@@ -75,7 +75,7 @@
 				$\mathcal T$ is neither one-to-one nor onto.
 				The RREF of $M_{\mathcal T}$ is $\mat{1&0&-1\\0&1&0\\0&0&0}$.
 				$\Rank(\mathcal T)$ = $\Rank(M_{\mathcal T})$ = 2.
-				by the Rank-Nullity Theorem the nullity is 1.
+				by the rank-nullity theorem the nullity is 1.
 				An entire line of vectors is getting mapped to
 				$\vec{0}$ so there are distinct inputs that do not map to distinct
 				outputs,

--- a/book/modules/module12.tex
+++ b/book/modules/module12.tex
@@ -67,7 +67,7 @@ can be expressed as
 Therefore, $\mathcal T$ is one-to-one if and only if $\Nullity(\mathcal T)=0$.
 If $\mathcal T$ is onto, then $\Range(\mathcal T)=\R^m$ and so $\Rank(\mathcal T)=m$. 
 
-Now, suppose $\mathcal T$ is one-to-one and onto. By the Rank-nullity Theorem,
+Now, suppose $\mathcal T$ is one-to-one and onto. By the rank-nullity theorem,
 \[
 	\Rank(\mathcal T)+\Nullity(\mathcal T) = 0+m=m=n=\Dim(\text{domain of $\mathcal T$}),
 \]


### PR DESCRIPTION
- "Rank-nullity Theorem" in titles
- "Rank-Nullity Theorem" in the module 11 section heading
- "rank-nullity theorem" otherwise

Also modified the module 14 determinant definition: change the linear transformation "X" to a calligraphic "T". Indices are also modified accordingly. 