### PR TITLE
Prevent module 11 solutions from overlapping appendix 3 banner.

### DIFF
--- a/book/modules/module11-exercises.tex
+++ b/book/modules/module11-exercises.tex
@@ -19,24 +19,38 @@
 		\begin{solution}
 
 			\begin{enumerate}
-				\item $M_{1} = \mat{1&2&1\\3&1&-2\\8&6&-2}$ $\Null(M_{1})=\Set*{\vec{x}
-					\in \R^3: M_1 \vec{x}=\vec 0}$ Therefore we need to
-					solve $\mat{M_1|\vec0}$. And
-					$\rref(M_{1})=\mat{1&0&-1\\0&1&1\\0&0&0}$. $\Null(M_{1})=\Set*{\vec
-					x \in \R^3:\vec x = s\mat{1\\-1\\1} \; \text{for
-					some }
-					s\in\R}= \Span \Set*{\mat{1\\-1\\1}}$ $\Col(A) = \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6},\mat{1\\-2\\-2}}=
-					\Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6}}$ $\Row(A)=\Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2},\mat{8\\6\\-2}}=\Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2}}=\Span\Set*{\mat{1\\0\\-1},\mat{0\\1\\1}}$
+				\item $M_{1} = \mat{1&2&1\\3&1&-2\\8&6&-2}$;\, $\rref(M_{1})=\mat{1&0&-1\\0&1&1\\0&0&0}$.
+				
+					$\Null(M_{1})=\Set*{\vec{x} \in \R^3: M_1 \vec{x}=\vec 0}$;
+					therefore, we need to solve $\mat{M_1|\vec0}$.
+					\begin{align*}
+						\Null(M_{1}) &= \Set*{\vec x \in \R^3:\vec x = s\mat{1\\-1\\1} \; \text{for some } s\in\R}\\
+						             &= \Span\Set*{\mat{1\\-1\\1}}
+					\end{align*}
+					\begin{align*}
+						\Col(M_{1}) &= \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6},\mat{1\\-2\\-2}}\\
+						        &= \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6}}
+					\end{align*}
+					\begin{align*}
+						\Row(M_{1}) &= \Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2},\mat{8\\6\\-2}}\\
+						        &= \Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2}}\\
+								&= \Span\Set*{\mat{1\\0\\-1},\mat{0\\1\\1}}
+					\end{align*}
 
-				\item $\rref(M_{2})=\mat{1&0&4/3\\0&1&1/2}$ $\Null(M_{2})=\Span\Set*{\mat{4/3\\1/2\\-1}};\;\Col(M_{2})=\Span\Set*{\mat{0\\3},\mat{2\\2}}=\R^{2}$
-					$\Row(M_{2})=\Span\Set*{\mat{0\\2\\1},\mat{3\\2\\5}}$
+				\item $\rref(M_{2})=\mat{1&0&4/3\\0&1&1/2}$.
+					$$\Null(M_{2})=\Span\Set*{\mat{4/3\\1/2\\-1}}$$
+					$$\Col(M_{2})=\Span\Set*{\mat{0\\3},\mat{2\\2}}=\R^{2}$$
+					$$\Row(M_{2})=\Span\Set*{\mat{0\\2\\1},\mat{3\\2\\5}}$$
 
-				\item $\rref(M_{3})=\mat{1&0\\0&1\\0&0};\; \Null(M_{3})=\Set*{\mat{0\\0}}$
-					$\Col(M_{3})=\Span\Set*{\mat{1\\3\\4},\mat{2\\1\\0}};\;
-					\Row(M_{3})=\Span\Set*{\mat{1\\2},\mat{3\\1}}=\R^{2}$
+				\item $\rref(M_{3})=\mat{1&0\\0&1\\0&0}$.
+					$$\Null(M_{3})=\Set*{\mat{0\\0}}$$
+					$$\Col(M_{3})=\Span\Set*{\mat{1\\3\\4},\mat{2\\1\\0}}$$
+					$$\Row(M_{3})=\Span\Set*{\mat{1\\2},\mat{3\\1}}=\R^{2}$$
 
-				\item $\rref(M_{4})=I_{4\times4}\implies \Null(M_{4})=\Set*{\mat{0\\0\\0\\0}}$
-					$\Col(M_{4})=\R^{4}; \; \Row(M_{4})=\R^{4}$
+				\item $\rref(M_{4})=I_{4\times4}$.
+					$$\Null(M_{4})=\Set*{\mat{0\\0\\0\\0}}$$
+					$$\Col(M_{4})=\R^{4}$$
+					$$\Row(M_{4})=\R^{4}$$
 			\end{enumerate}
 		\end{solution}
 

--- a/book/modules/module11-exercises.tex
+++ b/book/modules/module11-exercises.tex
@@ -29,12 +29,12 @@
 					\end{align*}
 					\begin{align*}
 						\Col(M_{1}) &= \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6},\mat{1\\-2\\-2}}\\
-						        &= \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6}}
+									&= \Span\Set*{\mat{1\\3\\8},\mat{2\\1\\6}}
 					\end{align*}
 					\begin{align*}
 						\Row(M_{1}) &= \Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2},\mat{8\\6\\-2}}\\
-						        &= \Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2}}\\
-								&= \Span\Set*{\mat{1\\0\\-1},\mat{0\\1\\1}}
+									&= \Span\Set*{\mat{1\\2\\1},\mat{3\\1\\-2}}\\
+									&= \Span\Set*{\mat{1\\0\\-1},\mat{0\\1\\1}}
 					\end{align*}
 
 				\item $\rref(M_{2})=\mat{1&0&4/3\\0&1&1/2}$.


### PR DESCRIPTION
Solution 1(a):
- put each fundamental subspace in its own `\align*` environment
- change matrix `A` to `M_1`
- change sentences

Solution 1(b),(c),(d):
- put each fundamental subspace on its own line using `$$$$`

![2020-07-02 (19:13-29)](https://user-images.githubusercontent.com/48996448/86416520-26c95100-bc98-11ea-8eb8-ab7bc07ab85c.png)
