### PR TITLE
Use \R instead of \mathbb{R}.

### DIFF
--- a/book/modules/appendix1-exercises.tex
+++ b/book/modules/appendix1-exercises.tex
@@ -116,7 +116,7 @@
 
 				\item There are vectors $\vec{b}$ that makes the system consistent.
 					For instance, any vector $\vec b = \vec b=\mat{t \\ 2t}$ where
-					$t\in\mathbb{R}$ makes the system consistent. Since there
+					$t\in\R$ makes the system consistent. Since there
 					are infinitely many real numbers, we conclude that there are
 					infinitely many vectors $\vec b$ that makes the system consistent.
 
@@ -135,7 +135,7 @@
 				\item There are vectors $\vec b$ that makes the system inconsistent.
 					For instance, $\mat{10 \\ 24}$ is is such a vector. In
 					general, any vector $\vec b$ with $\vec b=\mat{5t \\ 12t}$ where
-					$t\in\mathbb{R}$ ($t\ne 0$) makes the system inconsistent.
+					$t\in\R$ ($t\ne 0$) makes the system inconsistent.
 					Since there are infinitely many real numbers, we conclude that
 					there are infinitely many vectors $\vec b$ that makes the system
 					inconsistent.


### PR DESCRIPTION
There were two `\mathbb{R}`'s still in the appendix 1 solutions. They have been changed to `\R`.