### PR TITLE
Some potential typos fixed.

### DIFF
--- a/book/modules/module11.tex
+++ b/book/modules/module11.tex
@@ -250,7 +250,7 @@ Or, phrased another way, the solution set to $M\vec x=\vec b$ is
 	\Null(M)+\Set{\vec p}.
 \]
 
-In the context of what we already know about lines and translated subspaces, this makes perfect sense. We know
+In the context of what we already know about lines and translated spans, this makes perfect sense. We know
 that the solution set to $M\vec x=\vec b$ is a line (which doesn't pass through the origin) and may therefore
 be written as a translated span $\Span\Set{\vec d}+\Set{\vec p}$. Here $\vec d$ is a direction vector for the line
 and $\vec p$ is a point on the line.

--- a/book/modules/module12.tex
+++ b/book/modules/module12.tex
@@ -163,7 +163,6 @@ for a function to be invertible.}.
 Since every matrix induces a linear transformation, we can use the facts we know about invertible linear
 transformations to produce facts about invertible matrices. In particular:
 \begin{itemize}
-	\item An $n\times m$ matrix $A$ is invertible if and only if $\Nullity(A)=0$ and $\Rank(A)=n$.
 	\item An $n\times n$ matrix $A$ is invertible if and only if $\Nullity(A)=0$.
 	\item An $n\times n$ matrix $A$ is invertible if and only if $\Rank(A)=n$.
 \end{itemize}

--- a/book/modules/module12.tex
+++ b/book/modules/module12.tex
@@ -163,6 +163,7 @@ for a function to be invertible.}.
 Since every matrix induces a linear transformation, we can use the facts we know about invertible linear
 transformations to produce facts about invertible matrices. In particular:
 \begin{itemize}
+	\item An $n\times m$ matrix $A$ is invertible if and only if $\Nullity(A)=0$ and $\Rank(A)=n$.
 	\item An $n\times n$ matrix $A$ is invertible if and only if $\Nullity(A)=0$.
 	\item An $n\times n$ matrix $A$ is invertible if and only if $\Rank(A)=n$.
 \end{itemize}


### PR DESCRIPTION
The first potential typo is from module 11, page 131:

![](https://user-images.githubusercontent.com/63186767/98147733-b8d9a400-1e9a-11eb-8320-a06952052d12.png)

the definition "translated subspace" only occurred once (there) through the whole book.
I think changing this into "translated spans" will be better.

The second potential typo is from module 12, page 149:

![image](https://user-images.githubusercontent.com/63186767/98451455-97372180-2113-11eb-826e-16c8491f71ed.png)

This have been discussed in Persuall:

![image](https://user-images.githubusercontent.com/63186767/98451466-b03fd280-2113-11eb-9c12-d0e4815a4c23.png)

