### PR TITLE
Missing word in PAR Question (WA 2)

### DIFF
--- a/teaching-materials/par/WA2.tex
+++ b/teaching-materials/par/WA2.tex
@@ -296,7 +296,7 @@
 			Explain to Max and Lily (i) what is going on, (ii) why is there confusion, and (iii) is one more right
 			than the other (or are they both wrong).
 	Your explanation must include linear algebra terminology, and
-		should be aimed at the level of a MAT223 who has missed the last two weeks of class. 
+		should be aimed at the level of a MAT223 student who has missed the last two weeks of class. 
 		That means, you should explain any newer linear algebra concepts/terminology you use.
 
 	


### PR DESCRIPTION
PAR Part 2 in writing assignment 2 had
"...should be aimed at the level of a MAT223 who has missed the last two weeks of class."

Changed to
"...should be aimed at the level of a MAT223 **student** who has missed the last two weeks of class."