### PR TITLE
Added a footnote in Module 2 for row reduction

### DIFF
--- a/book/modules/module2.tex
+++ b/book/modules/module2.tex
@@ -485,7 +485,7 @@ the plane $\mathcal P$ can be written in vector form as
 	\]
 	This system is underdetermined (there are four variables and three equations). If $\mathcal P_1$ 
 	and $\mathcal P_2$ indeed intersect in a line, we know there must an infinite number
-	of solutions to this system. After row reducing\footnote{See Appendix \ref{APPSLEI}, System \eqref{EQVECEQ2} and \eqref{EQEQUIVSYS}.}, we see
+	of solutions to this system. After row reducing\footnote{ See Appendix \ref{APPSLEI}, System \eqref{EQVECEQ2} and \eqref{EQEQUIVSYS}.}, we see
 	\[
 		\mat{a\\b\\c\\d} = \matc{r\\r/2-1\\-1\\r/2+1}
 	\]

--- a/book/modules/module2.tex
+++ b/book/modules/module2.tex
@@ -485,7 +485,7 @@ the plane $\mathcal P$ can be written in vector form as
 	\]
 	This system is underdetermined (there are four variables and three equations). If $\mathcal P_1$ 
 	and $\mathcal P_2$ indeed intersect in a line, we know there must an infinite number
-	of solutions to this system. After row reducing, we see
+	of solutions to this system. After row reducing\footnote{See Appendix 1, System (15)}, we see
 	\[
 		\mat{a\\b\\c\\d} = \matc{r\\r/2-1\\-1\\r/2+1}
 	\]

--- a/book/modules/module2.tex
+++ b/book/modules/module2.tex
@@ -485,7 +485,7 @@ the plane $\mathcal P$ can be written in vector form as
 	\]
 	This system is underdetermined (there are four variables and three equations). If $\mathcal P_1$ 
 	and $\mathcal P_2$ indeed intersect in a line, we know there must an infinite number
-	of solutions to this system. After row reducing\footnote{See Appendix 1, System (15).}, we see
+	of solutions to this system. After row reducing\footnote{See Appendix 1, System (14) and (15).}, we see
 	\[
 		\mat{a\\b\\c\\d} = \matc{r\\r/2-1\\-1\\r/2+1}
 	\]

--- a/book/modules/module2.tex
+++ b/book/modules/module2.tex
@@ -485,7 +485,7 @@ the plane $\mathcal P$ can be written in vector form as
 	\]
 	This system is underdetermined (there are four variables and three equations). If $\mathcal P_1$ 
 	and $\mathcal P_2$ indeed intersect in a line, we know there must an infinite number
-	of solutions to this system. After row reducing\footnote{See Appendix 1, System (15)}, we see
+	of solutions to this system. After row reducing\footnote{See Appendix 1, System (15).}, we see
 	\[
 		\mat{a\\b\\c\\d} = \matc{r\\r/2-1\\-1\\r/2+1}
 	\]


### PR DESCRIPTION
The current version of this module is a little confusing for students who do not know what row reduction is or how to do it. There is an example of row reduction in the Appendix, and this footnote refers to it.