### PR TITLE
fix vector n notation typo (page 54)

### DIFF
--- a/book/modules/module4.tex
+++ b/book/modules/module4.tex
@@ -221,7 +221,7 @@ this case, we call $\vec n$ a \emph{normal vector} for $\ell$.
 In $\R^2$, normal vectors provide yet another way to describe lines, including lines which don't pass
 through the origin.
 
-Let $n=\mat{1\\2}$ as before, and fix $\vec p=\mat{1\\1}$. If we draw the set of all vectors
+Let $\vec n=\mat{1\\2}$ as before, and fix $\vec p=\mat{1\\1}$. If we draw the set of all vectors
 orthogonal to $\vec n$ but \emph{root all the vectors at $\vec p$}, again we get a line, but this
 time the line passes through $\vec p$.
 


### PR DESCRIPTION
Found a small typo where n is not written as a vector in the middle of page 54.